### PR TITLE
handle tilde expansion for OS home directory

### DIFF
--- a/node/internal.ts
+++ b/node/internal.ts
@@ -6,6 +6,7 @@ import util = require('util');
 import tcm = require('./taskcommand');
 import vm = require('./vault');
 import semver = require('semver');
+const home = os.homedir();
 
 /**
  * Hash table of known variable info. The formatted env var name is the lookup key.
@@ -401,7 +402,11 @@ export function _which(tool: string, check?: boolean): string {
         }
 
         // return the first match
-        for (let directory of directories) {
+        for (var directory of directories) {
+            // TODO: fix to make tests pass.
+            // if ( !!home && process.platform == 'win32') {
+            //     directory = _unTildify(directory);
+            // }
             let filePath = _tryGetExecutablePath(directory + path.sep + tool, extensions);
             if (filePath) {
                 _debug(`found: '${filePath}'`);
@@ -500,6 +505,22 @@ function _tryGetExecutablePath(filePath: string, extensions: string[]): string {
     }
 
     return '';
+}
+
+/**
+ * Deal with expanding tilde (~) to home directory on nix which really is a bash thing
+ * taken from https://github.com/sindresorhus/untildify
+ * @param filePath file and path to check
+ * @return the filePath prefix
+ */
+function _unTildify(filePath) {
+    console.log("##### %s", filePath);
+    if (typeof filePath !== 'string') {
+        throw new TypeError(`Expected a string, got ${typeof filePath}`);
+    }
+    if (filePath[0] !== '~') return filePath;
+
+    return home ? filePath.replace(/^~($|\/|\\)/, `${home}$1`) : filePath;
 }
 
 export function _legacyFindFiles_convertPatternToRegExp(pattern: string): RegExp {

--- a/node/test/dirtests.ts
+++ b/node/test/dirtests.ts
@@ -113,6 +113,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
     it('which() searches path in order', function (done) {
+        // TODO:SPC Mimic this one.
         this.timeout(1000);
 
         // create a chcp.com/bash override file
@@ -349,6 +350,48 @@ describe('Dir Operation Tests', function () {
             if (process.platform == 'win32') {
                 assert.equal(tl.which(testDirName + '\\' + fileName) || '', '');
             }
+        }
+        finally {
+            process.env['PATH'] = originalPath;
+        }
+
+        done();
+    });
+    it('which() handles tilde ~ prefix', function (done) {
+        // TODO:SPC Mimic this one.
+        this.timeout(1000);
+
+        // create a chcp.com/bash override file
+        let testPath = path.join(os.homedir(), 'which-expands-tilde-in-path');
+        let tildePath = path.join('~', 'which-expands-tilde-in-path');
+        tl.mkdirP(testPath);
+        let fileName;
+        if (process.platform == 'win32') { // TODO: this might apply bash in windows
+            fileName = 'chcp.com';
+        }
+        else {
+            fileName = 'bash';
+        }
+
+        let filePath = path.join(testPath, fileName);
+        fs.writeFileSync(filePath, '');
+        if (process.platform != 'win32') {
+            testutil.chmod(filePath, '+x');
+        }
+        let originalPath = process.env['PATH'];
+        try {
+            // sanity - regular chcp.com/bash should be found
+            let originalWhich = tl.which(fileName);
+            assert((originalWhich || '') != '', fileName + 'should be found');
+
+            // TODO: need to deal with $HOME and ~ 
+            // modify PATH
+            process.env['PATH'] = tildePath + path.delimiter + process.env['PATH'];
+
+            // override chcp.com/bash should be found
+            assert(tl.which(fileName), filePath);
+            assert(testPath !== tildePath, "these shouldn't match: " + testPath + "  " + tildePath);
+
         }
         finally {
             process.env['PATH'] = originalPath;


### PR DESCRIPTION
this is related to https://github.com/Microsoft/vsts-tasks/issues/4302

This handles tilde `~` expansion for bash shells where the `PATH` has a tilde such as `~/bin`.  

Since node's `fs.statSync` doesn't expand tilde's, See this conversation as well as to why node team didn't fix. https://github.com/nodejs/node/issues/684#issuecomment-72344577