### PR TITLE
Add missing "type" on connectService string pattern

### DIFF
--- a/tasks.schema.json
+++ b/tasks.schema.json
@@ -153,6 +153,7 @@
                 ]
               },
               {
+                "type": "string",
                 "pattern": "^connectedService\\:.+$"
               }
             ]


### PR DESCRIPTION
It is required for some tools (such as json2ts) to work properly. 
Other similar pattern have the type specified so I assume this has just been forgotten.