### PR TITLE
Change reference to VSTS to Azure DevOps

### DIFF
--- a/powershell/Docs/UsingOM.md
+++ b/powershell/Docs/UsingOM.md
@@ -1,4 +1,4 @@
-# Using the VSTS .NET SDKs
+# Using the Azure DevOps .NET SDKs
 
 ## Bundle the SDK with your task
 Bundle the subset of the SDK required by your task.


### PR DESCRIPTION
I shared these instructions with someone who is *very* new to ~VSTS~ Azure DevOps and was confused by the title of this doc. The naming/branding change will undoubtedly take a while to get through, but hopefully this little bit helps.