### PR TITLE
Added support for empty string in toolRunner

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -20,7 +20,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -53,9 +53,9 @@
       "integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.5",
+        "typedarray": "0.0.6"
       }
     },
     "core-util-is": {
@@ -97,12 +97,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "growl": {
@@ -129,9 +129,9 @@
       "integrity": "sha1-jORHvbW2xXf4pj4/p4BW7Eu02/s=",
       "dev": true,
       "requires": {
-        "caseless": "~0.11.0",
-        "concat-stream": "^1.4.6",
-        "http-response-object": "^1.0.0"
+        "caseless": "0.11.0",
+        "concat-stream": "1.6.1",
+        "http-response-object": "1.1.0"
       }
     },
     "http-response-object": {
@@ -146,8 +146,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -167,7 +167,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -220,7 +220,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "path-is-absolute": {
@@ -241,7 +241,7 @@
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "dev": true,
       "requires": {
-        "asap": "~2.0.3"
+        "asap": "2.0.6"
       }
     },
     "q": {
@@ -261,13 +261,13 @@
       "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
       "dev": true,
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.0.3",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
       }
     },
     "safe-buffer": {
@@ -292,7 +292,7 @@
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.1"
       }
     },
     "supports-color": {
@@ -301,7 +301,7 @@
       "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
       "dev": true,
       "requires": {
-        "has-flag": "^2.0.0"
+        "has-flag": "2.0.0"
       }
     },
     "sync-request": {
@@ -310,9 +310,9 @@
       "integrity": "sha1-yqEjWq+Im6UBB2oYNMQ2gwqC+3M=",
       "dev": true,
       "requires": {
-        "concat-stream": "^1.4.7",
-        "http-response-object": "^1.0.1",
-        "then-request": "^2.0.1"
+        "concat-stream": "1.6.1",
+        "http-response-object": "1.1.0",
+        "then-request": "2.2.0"
       }
     },
     "then-request": {
@@ -321,12 +321,12 @@
       "integrity": "sha1-ZnizL6DKIY/laZgbvYhxtZQGDYE=",
       "dev": true,
       "requires": {
-        "caseless": "~0.11.0",
-        "concat-stream": "^1.4.7",
-        "http-basic": "^2.5.1",
-        "http-response-object": "^1.1.0",
-        "promise": "^7.1.1",
-        "qs": "^6.1.0"
+        "caseless": "0.11.0",
+        "concat-stream": "1.6.1",
+        "http-basic": "2.5.1",
+        "http-response-object": "1.1.0",
+        "promise": "7.3.1",
+        "qs": "6.5.1"
       }
     },
     "typedarray": {

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-task-lib",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "VSTS Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",

--- a/node/test/toolrunnertests.ts
+++ b/node/test/toolrunnertests.ts
@@ -1204,6 +1204,16 @@ describe('Toolrunner Tests', function () {
         assert.equal((node as any).args.toString(), 'foo=bar " baz,-x,-y', 'should be foo=bar " baz,-x,-y');
         done();
     })
+    it('handles empty string', function (done) {
+        this.timeout(10000);
+
+        var node = tl.tool(tl.which('node', true));
+        node.line('"" -x');
+        node.arg('-y');
+        assert.equal((node as any).args.length, 3, 'should have 3 args');
+        assert.equal((node as any).args.toString(), ',-x,-y', 'should be ,-x,-y');
+        done();
+    })
     it('handles literal path', function (done) {
         this.timeout(10000);
 

--- a/node/toolrunner.ts
+++ b/node/toolrunner.ts
@@ -100,6 +100,18 @@ export class ToolRunner extends events.EventEmitter {
         for (var i = 0; i < argString.length; i++) {
             var c = argString.charAt(i);
 
+            if (c === ' ' && !inQuotes) {
+                if (!lastCharWasSpace) {
+                    args.push(arg);
+                    arg = '';
+                }
+                lastCharWasSpace = true;
+                continue;
+            }
+            else {
+                lastCharWasSpace = false;
+            }
+
             if (c === '"') {
                 if (!escaped) {
                     inQuotes = !inQuotes;
@@ -107,22 +119,11 @@ export class ToolRunner extends events.EventEmitter {
                 else {
                     append(c);
                 }
-                lastCharWasSpace = false;
                 continue;
             }
 
             if (c === "\\" && inQuotes) {
                 escaped = true;
-                lastCharWasSpace = false;
-                continue;
-            }
-
-            if (c === ' ' && !inQuotes) {
-                if (!lastCharWasSpace) {
-                    args.push(arg);
-                    arg = '';
-                }
-                lastCharWasSpace = true;
                 continue;
             }
 

--- a/node/toolrunner.ts
+++ b/node/toolrunner.ts
@@ -84,6 +84,7 @@ export class ToolRunner extends events.EventEmitter {
 
         var inQuotes = false;
         var escaped = false;
+        var lastCharWasSpace = true;
         var arg = '';
 
         var append = function (c) {
@@ -106,26 +107,30 @@ export class ToolRunner extends events.EventEmitter {
                 else {
                     append(c);
                 }
+                lastCharWasSpace = false;
                 continue;
             }
 
             if (c === "\\" && inQuotes) {
                 escaped = true;
+                lastCharWasSpace = false;
                 continue;
             }
 
             if (c === ' ' && !inQuotes) {
-                if (arg.length > 0) {
+                if (!lastCharWasSpace) {
                     args.push(arg);
                     arg = '';
                 }
+                lastCharWasSpace = true;
                 continue;
             }
 
             append(c);
+            lastCharWasSpace = false;
         }
 
-        if (arg.length > 0) {
+        if (!lastCharWasSpace) {
             args.push(arg.trim());
         }
 


### PR DESCRIPTION
I still lack the context to be sure that this is a desired change/worth any potential cost in back compat, but this allows users to specify an empty string as an arg for toolrunner. The issue this addresses seems to be a pretty valid use case that I don't see a workaround for.

Fixes #277 
