### PR TITLE
Don't swallow [command] string in mock-toolrunner

### DIFF
--- a/node/mock-toolrunner.ts
+++ b/node/mock-toolrunner.ts
@@ -220,6 +220,9 @@ export class ToolRunner extends events.EventEmitter {
 
             ops.outStream.write('[command]' + cmdString + os.EOL);
         }
+        else {
+            ops.outStream.write('[command]');
+        }
 
         // TODO: filter process.env
         var res = mock.getResponse('exec', cmdString, debug);


### PR DESCRIPTION
Fixes #212