### PR TITLE
Mock getInputs

### DIFF
--- a/node/mock-task.ts
+++ b/node/mock-task.ts
@@ -4,6 +4,7 @@ import path = require('path');
 import fs = require('fs');
 import os = require('os');
 import util = require('util');
+import im = require('./internal');
 import task = require('./task');
 import tcm = require('./taskcommand');
 import trm = require('./mock-toolrunner');
@@ -64,7 +65,18 @@ module.exports.getVariable = task.getVariable;
 module.exports.setVariable = task.setVariable;
 module.exports.getTaskVariable = task.getTaskVariable;
 module.exports.setTaskVariable = task.setTaskVariable;
-module.exports.getInput = task.getInput;
+
+var reloadedData = false;
+function getInput(name: string, required?: boolean) {
+    var input = process.env['INPUT_' + name.replace(' ', '_').toUpperCase()];
+    if (input) {
+        return input;
+    }
+    else {
+        return task.getInput(name, required);
+    }
+}
+module.exports.getInput = getInput;
 module.exports.getBoolInput = task.getBoolInput;
 module.exports.getDelimitedInput = task.getDelimitedInput;
 module.exports.filePathSupplied = task.filePathSupplied;

--- a/node/test/mocktests.ts
+++ b/node/test/mocktests.ts
@@ -5,12 +5,11 @@
 /// <reference path="../_build/task.d.ts" />
 
 import assert = require('assert');
-import * as mt from '../_build/mock-task';
-import * as mtm from '../_build/mock-test';
+import * as mr from '../_build/mock-run';
 import * as mtr from '../_build/mock-toolrunner';
 import * as ma from '../_build/mock-answer';
-import * as tl from '../_build/task';
 
+const mt = require('../_build/mock-task');
 import testutil = require('./testutil');
 
 describe('Mock Tests', function () {
@@ -183,5 +182,18 @@ describe('Mock Tests', function () {
         
         assert(tool, "tool should not be null");
         assert(rc == 0, "rc is 0");
-    })                
+    })
+
+    it('getInputs gets inputs that are set', () => {
+        const runner: mr.TaskMockRunner = new mr.TaskMockRunner('path');
+        runner.setInput('key', 'val');
+
+        assert.equal(mt.getInput('key', true), 'val', 'input key should have value val');
+        process.env['AGENT_TEMPDIRECTORY'] = '/build/temp';
+        assert.equal(mt.getInput('key', true), 'val', 'input key should have value val even if AGENT_TEMPDIRECTORY is set');
+    })
+    
+    it('getInputs gets inputs that are set when AGENT_TEMPDIRECTORY is set', async () => {
+        
+    })
 });


### PR DESCRIPTION
Currently, the mock of getInputs fails if the base directory is changed since setInputs doesn't adjust for this and getInputs is not mocked. This PR mocks getInputs.

Fixes #372 