### PR TITLE
Get tests running again

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,9 @@ jobs:
     displayName: (azure-pipelines-task-lib) use node 5.10.1
 
   # build/test
-  - script: node make.js test
+  - script: |
+      chcp 437
+      node make.js test
     workingDirectory: node
     displayName: (azure-pipelines-task-lib) node make.js test  
 
@@ -39,7 +41,9 @@ jobs:
       versionSpec: "6.10.3"
 
   # build/test
-  - script: node make.js test
+  - script: |
+      chcp 437
+      node make.js test
     displayName: (azure-pipelines-task-lib) node make.js test
     workingDirectory: node
 


### PR DESCRIPTION
Code page changes seem to have broken csc.exe. I'm investigating further, but this should at least get them up and running again.

Fixes #492 