### PR TITLE
Consider adding Stale bot to help manage old issues/PRs

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,29 @@
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 60
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+daysUntilClose: 14
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - not stale
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: wontfix
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed in 14 days if no further activity occurs.
+  This behavior can be disabled for this issue by assigning the `not stale` label.
+  Thank you for your contributions.
+
+# Comment to post when closing a stale Issue or Pull Request.
+closeComment: >
+  This issue has been closed due to inactivity.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30


### PR DESCRIPTION
I like the idea of trying to further automate our issue/pr response with things like `tag-ur-it` and I think this could be another helpful area to try to automate. This PR assumes we would use [`probot/stale`](https://github.com/probot/stale), but we could also try to build this into `tag-ur-it` if we decide that's not a good fit or if we don't want to manage multiple bots.

I think if we decide we want to automate this, it makes sense to start in this repo where the issue load is more manageable and then move into `azure-pipelines-tasks` when we have a good sense of what good parameters are for things like `daysUntilStale`. I think it could also be useful in our other OSS repos, but they're all `<=10` issues so it feels less important.