### PR TITLE
Enable large numbers of children to be pushed in find

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "3.0.0-preview",
+  "version": "3.1.0-preview",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "3.0.0-preview",
+  "version": "3.1.0-preview",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",

--- a/node/task.ts
+++ b/node/task.ts
@@ -918,7 +918,9 @@ export function find(findPath: string, options?: FindOptions): string[] {
                 let childItems: _FindItem[] =
                     fs.readdirSync(item.path)
                         .map((childName: string) => new _FindItem(path.join(item.path, childName), childLevel));
-                stack.push(...childItems.reverse());
+                for (var i = childItems.length - 1; i >= 0; i--) {
+                    stack.push(childItems[i]);
+                }
             }
             else {
                 debug(`  ${item.path} (file)`);


### PR DESCRIPTION
Right now, if there are too many childItems this exceeds the stack call size. This fixes this problem by pushing them one by one instead of with the `…` operator.

Fixes #408 