### PR TITLE
OSX/Linux platform - handle double quotes while logging command

### DIFF
--- a/node/test/toolrunnertests.ts
+++ b/node/test/toolrunnertests.ts
@@ -1254,6 +1254,43 @@ describe('Toolrunner Tests', function () {
                     done(err);
                 });
         });
+
+        // ----------------------------------------
+        // double quotes in arg (OSX/Linux)
+        // ----------------------------------------
+
+        it('exec with double quotes in args (OSX/Linux)', function (done) {
+            this.timeout(10000);
+            let bashPath = tl.which('bash');
+            let bash = tl.tool(bashPath)
+                .arg('-c')
+                .arg('echo $0')
+                .arg('hello"world"')
+            let outStream = testutil.createStringStream();
+            let options = <trm.IExecOptions>{ outStream: <stream.Writable>outStream, windowsVerbatimArguments: true };
+            let output = '';
+            bash.on('stdout', (data) => {
+                output += data.toString();
+            });
+            bash.exec(options)
+                .then(function (code) {
+                    assert.equal(code, 0, 'return code should be 0');
+                    // validate the [command] header
+                    assert.equal(
+                        outStream.getContents().split(os.EOL)[0],
+                        '[command]' + bashPath + ' -c echo $0 hello\\"world\\"',
+                        '[command] header should match');
+                    // validate stdout
+                    assert.equal(
+                        output.trim(),
+                        'hello"world"',
+                        'stdout should match');
+                    done();
+                })
+                .fail(function (err) {
+                    done(err);
+                });
+        });
     }
     else { // process.platform == 'win32'
 

--- a/node/toolrunner.ts
+++ b/node/toolrunner.ts
@@ -170,6 +170,10 @@ export class ToolRunner extends events.EventEmitter {
             // on Unix, execvp() takes an arg array.
             cmd += toolPath;
             args.forEach((a: string): void => {
+                // Prefix all occurences of '"' character with '\' character explicitly,
+                // so that the arguments containing double quotes are printed correctly
+                // in the logs.
+                a = a.replace(/\"/g, "\\\"");
                 cmd += ` ${a}`;
             });
         }

--- a/node/toolrunner.ts
+++ b/node/toolrunner.ts
@@ -170,9 +170,15 @@ export class ToolRunner extends events.EventEmitter {
             // on Unix, execvp() takes an arg array.
             cmd += toolPath;
             args.forEach((a: string): void => {
-                // Prefix all occurences of '"' character with '\' character explicitly,
+                // Prefix all occurences of " character with \ character explicitly,
                 // so that the arguments containing double quotes are printed correctly
                 // in the logs.
+                // Without this, secret masking does not work when the original input
+                // contains escaped double quotes character.
+                // Example: An argument entered as example\"string in the UI, will have
+                // value example"string. While passing the argument to the command, it
+                // is passed as example\"string, where as in the logs, it appears as
+                // example"string.
                 a = a.replace(/\"/g, "\\\"");
                 cmd += ` ${a}`;
             });


### PR DESCRIPTION
Double quotes character present in the arguments are printed without the escape character (\\). Adding it explicitly to the cmd string.

Ex. A command mycmd running with an argument myarg (myarg = 'my\\"arg'),
is logged as: mycmd my"arg
but its actually executed as: mycmd my\\"arg


