### PR TITLE
Add setSecret to mock-task.

### DIFF
--- a/node/mock-task.ts
+++ b/node/mock-task.ts
@@ -54,6 +54,7 @@ export function loc(key: string, ...args: any[]): string {
 //-----------------------------------------------------
 module.exports.getVariable = task.getVariable;
 module.exports.setVariable = task.setVariable;
+module.exports.setSecret = task.setSecret;
 module.exports.getTaskVariable = task.getTaskVariable;
 module.exports.setTaskVariable = task.setTaskVariable;
 module.exports.getInput = task.getInput;

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "3.0.0-preview",
+  "version": "3.0.1-preview",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "3.0.0-preview",
+  "version": "3.0.1-preview",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",
@@ -27,10 +27,10 @@
   "dependencies": {
     "minimatch": "3.0.4",
     "mockery": "^1.7.0",
-    "uuid": "^3.0.1",
     "q": "^1.1.2",
     "semver": "^5.1.0",
-    "shelljs": "^0.3.0"
+    "shelljs": "^0.3.0",
+    "uuid": "^3.0.1"
   },
   "devDependencies": {
     "mocha": "5.2.0",


### PR DESCRIPTION
Add a mock for `setSecret`. Currently unit tests fail if you try to use `setSecret` in your task.