### PR TITLE
Mock every exported function in task-lib.

### DIFF
--- a/node/mock-answer.ts
+++ b/node/mock-answer.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import * as fs from 'fs';
+import * as task from './task';
 
 export interface TaskLibAnswerExecResult {
     code: number,
@@ -14,6 +15,7 @@ export interface TaskLibAnswers {
     exist?: { [key: string]: boolean },
     find?: { [key: string]: string[] },
     findMatch?: { [key: string]: string[] },
+    getPlatform?: { [key: string]: task.Platform },
     ls?: { [key: string]: string },
     osType?: { [key: string]: string },
     rmRF?: { [key: string]: { success: boolean } },

--- a/node/mock-task.ts
+++ b/node/mock-task.ts
@@ -52,7 +52,9 @@ export function loc(key: string, ...args: any[]): string {
 //-----------------------------------------------------
 // Input Helpers
 //-----------------------------------------------------
+module.exports.assertAgent = task.assertAgent;
 module.exports.getVariable = task.getVariable;
+module.exports.getVariables = task.getVariables;
 module.exports.setVariable = task.setVariable;
 module.exports.setSecret = task.setSecret;
 module.exports.getTaskVariable = task.getTaskVariable;
@@ -200,6 +202,10 @@ export function writeFile(file: string, data: string|Buffer, options?: string|Fs
 
 export function osType(): string {
     return mock.getResponse('osType', 'osType', module.exports.debug);
+}
+
+export function getPlatform(): task.Platform {
+    return mock.getResponse('getPlatform', 'getPlatform', module.exports.debug);
 }
 
 export function cwd(): string {
@@ -439,6 +445,36 @@ export class CodeCoverageEnabler {
         module.exports.command('codecoverage.enable', buildProps, "");
     }
 }
+
+//-----------------------------------------------------
+// Task Logging Commands
+//-----------------------------------------------------
+exports.uploadFile = task.uploadFile;
+exports.prependPath = task.prependPath;
+exports.uploadSummary = task.uploadSummary;
+exports.addAttachment = task.addAttachment;
+exports.setEndpoint = task.setEndpoint;
+exports.setProgress = task.setProgress;
+exports.logDetail = task.logDetail;
+exports.logIssue = task.logIssue;
+
+//-----------------------------------------------------
+// Artifact Logging Commands
+//-----------------------------------------------------
+exports.uploadArtifact = task.uploadArtifact;
+exports.associateArtifact = task.associateArtifact;
+
+//-----------------------------------------------------
+// Build Logging Commands
+//-----------------------------------------------------
+exports.uploadBuildLog = task.uploadBuildLog;
+exports.updateBuildNumber = task.updateBuildNumber;
+exports.addBuildTag = task.addBuildTag;
+
+//-----------------------------------------------------
+// Release Logging Commands
+//-----------------------------------------------------
+exports.updateReleaseName = task.updateReleaseName;
 
 //-----------------------------------------------------
 // Tools

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "3.0.1-preview",
+  "version": "3.0.2-preview",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "3.0.1-preview",
+  "version": "3.0.2-preview",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",

--- a/node/test/mocktests.ts
+++ b/node/test/mocktests.ts
@@ -33,6 +33,29 @@ describe('Mock Tests', function () {
 
     });
 
+    // Verify mock-task exports all the non-deprecated functions exported by task. If a task-lib function isn't mocked,
+    // it's difficult to use in a task with unit tests.
+    it('mock-task exports every function in task', (done) => {
+        for (let memberName of Object.keys(tl)) {
+            // Deprecated functions don't need to be implemented.
+            // Tasks should updated instead.
+            if (memberName.toLowerCase().startsWith('legacy')) {
+                continue;
+            }
+
+            const member = tl[memberName];
+
+            if (typeof member === 'function') {
+                const mockMember = mt[memberName];
+                if (!mockMember || typeof mockMember !== typeof member) {
+                    assert.fail(`mock-task missing function exported by task: "${memberName}"`);
+                }
+            }
+        }
+
+        done();
+    });
+
     it('Mocks which and returns path on exists', (done) => {
         var a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "which": {
@@ -184,11 +207,11 @@ describe('Mock Tests', function () {
         tool.arg('--arg');
         tool.arg('foo');
         let rc: number = await tool.exec(<mtr.IExecOptions>{});
-        
+
         assert(tool, "tool should not be null");
         assert(rc == 0, "rc is 0");
     })
-    
+
     it('Mock toolRunner returns correct output', async () => {
         const expectedStdout = "atool output here" + os.EOL + "abc";
         const expectedStderr = "atool with this stderr output" + os.EOL + "def";
@@ -239,11 +262,11 @@ describe('Mock Tests', function () {
             }
         });
         await tool.exec(<mtr.IExecOptions>{});
-        
+
         assert.equal(numStdLineCalls, 2);
         assert.equal(numStdErrCalls, 2);
     })
-    
+
     it('Mock toolRunner returns correct output when ending on EOL', async () => {
         const expectedStdout = os.EOL;
         const expectedStderr = os.EOL;
@@ -279,7 +302,7 @@ describe('Mock Tests', function () {
             assert.equal("", out);
         });
         await tool.exec(<mtr.IExecOptions>{});
-        
+
         assert.equal(numStdLineCalls, 1);
         assert.equal(numStdErrCalls, 1);
     })


### PR DESCRIPTION
Every exported, non-deprecated task-lib function should be mocked. It's difficult to use task-lib functions in tasks unless they're mocked. Example from Microsoft/azure-pipelines-tasks repo:

```
    // TODO task-lib 2.4.0: `assertAgent` is not in mock-task
    // task.assertAgent('2.115.0');
```