### PR TITLE
Mock getVariable, getVariables and setVariable.

### DIFF
--- a/node/mock-answer.ts
+++ b/node/mock-answer.ts
@@ -83,6 +83,12 @@ export class MockAnswers {
             secret = secret || this._variableMap[key].secret;
         }
 
+        if (secret && value && value.match(/\r|\n/)) {
+            if (!this._variableMap.hasOwnProperty('SYSTEM_UNSAFEALLOWMULTILINESECRET') || this._variableMap['SYSTEM_UNSAFEALLOWMULTILINESECRET'].value.toUpperCase() != 'TRUE') {
+                throw new Error('loc_mock_LIB_MultilineSecret');
+            }
+        }
+
         const info: task.VariableInfo = {
             // task.setVariable uses name instead of the normalized key for the VariableInfo.
             name,

--- a/node/mock-answer.ts
+++ b/node/mock-answer.ts
@@ -35,7 +35,6 @@ export type MockedCommand = keyof TaskLibAnswers;
 export class MockAnswers {
     private _answers: TaskLibAnswers | undefined;
     private _variableMap: { [key: string]: task.VariableInfo } | undefined;
-    private _variables: task.VariableInfo[] | undefined;
 
     public initialize(answers: TaskLibAnswers) {
         if (!answers) {
@@ -80,12 +79,12 @@ export class MockAnswers {
 
         // once a secret always a secret
         const key: string = im._getVariableKey(name);
-        if (im._knownVariableMap.hasOwnProperty(key)) {
-            secret = secret || im._knownVariableMap[key].secret;
+        if (this._variableMap.hasOwnProperty(key)) {
+            secret = secret || this._variableMap[key].secret;
         }
 
         const info: task.VariableInfo = {
-            // task.setVariable uses name instead of the normalized key for VariableInfo.
+            // task.setVariable uses name instead of the normalized key for the VariableInfo.
             name,
             value,
             secret

--- a/node/mock-answer.ts
+++ b/node/mock-answer.ts
@@ -64,6 +64,11 @@ export class MockAnswers {
         }
     }
 
+    // Variables are mocked only if a variables answer is provided. This is to avoid breaking existing unit tests.
+    public get variablesMocked(): boolean {
+        return this._variableMap !== undefined;
+    }
+
     public get variableMap(): { [key: string]: task.VariableInfo } | undefined {
         return this._variableMap;
     }

--- a/node/mock-task.ts
+++ b/node/mock-task.ts
@@ -2,6 +2,7 @@
 import Q = require('q');
 import path = require('path');
 import fs = require('fs');
+import im = require('./internal');
 import task = require('./task');
 import tcm = require('./taskcommand');
 import trm = require('./mock-toolrunner');
@@ -62,12 +63,14 @@ module.exports.getBoolInput = task.getBoolInput;
 module.exports.getDelimitedInput = task.getDelimitedInput;
 module.exports.filePathSupplied = task.filePathSupplied;
 
-export function getVariable(name: string): string | undefined  {
-    const variables = mock.getVariableMap();
+export function getVariable(name: string): string | undefined {
+    const variableMap = mock.variableMap;
 
-    if (variables !== undefined) {
-        if (variables[name]) {
-            return variables[name].value;
+    if (variableMap !== undefined) {
+        const key = im._getVariableKey(name);
+
+        if (variableMap.hasOwnProperty(key)) {
+            return variableMap[key].value;
         } else {
             return undefined;
         }
@@ -78,14 +81,30 @@ export function getVariable(name: string): string | undefined  {
 }
 
 export function getVariables(): task.VariableInfo[] {
-    const variables = mock.getVariables();
+    const variableMap = mock.variableMap;
 
-    if (variables !== undefined) {
+    if (variableMap !== undefined) {
+        const variables:task.VariableInfo[] = [];
+        for (const name in variableMap) {
+            variables.push(variableMap[name]);
+        }
+
         return variables;
     }
 
     // variables answer not provided - fallthrough to task implementation.
     return task.getVariables();
+}
+
+export function setVariable(name: string, val: string, secret: boolean = false): void {
+    const variableMap = mock.variableMap;
+
+    if (variableMap !== undefined) {
+        mock.setVariable(name, val, secret);
+    }
+
+    // variables answer not provided - fallthrough to task implementation.
+    return task.setVariable(name, val, secret);
 }
 
 function getPathInput(name: string, required?: boolean, check?: boolean): string {

--- a/node/mock-task.ts
+++ b/node/mock-task.ts
@@ -64,47 +64,43 @@ module.exports.getDelimitedInput = task.getDelimitedInput;
 module.exports.filePathSupplied = task.filePathSupplied;
 
 export function getVariable(name: string): string | undefined {
-    const variableMap = mock.variableMap;
-
-    if (variableMap !== undefined) {
-        const key = im._getVariableKey(name);
-
-        if (variableMap.hasOwnProperty(key)) {
-            return variableMap[key].value;
-        } else {
-            return undefined;
-        }
+    if (!mock.variablesMocked) {
+        // variables answer not provided - fallthrough to task implementation.
+        return task.getVariable(name);
     }
 
-    // variables answer not provided - fallthrough to task implementation.
-    return task.getVariable(name);
+    const key = im._getVariableKey(name);
+    const variableMap = mock.variableMap!;
+
+    if (variableMap.hasOwnProperty(key)) {
+        return variableMap[key].value;
+    } else {
+        return undefined;
+    }
 }
 
 export function getVariables(): task.VariableInfo[] {
-    const variableMap = mock.variableMap;
-
-    if (variableMap !== undefined) {
-        const variables:task.VariableInfo[] = [];
-        for (const name in variableMap) {
-            variables.push(variableMap[name]);
-        }
-
-        return variables;
+    if (!mock.variablesMocked) {
+        // variables answer not provided - fallthrough to task implementation.
+        return task.getVariables();
     }
 
-    // variables answer not provided - fallthrough to task implementation.
-    return task.getVariables();
+    const variables:task.VariableInfo[] = [];
+    const variableMap = mock.variableMap!;
+
+    for (const name in variableMap) {
+        variables.push(variableMap[name]);
+    }
+    return variables;
 }
 
 export function setVariable(name: string, val: string, secret: boolean = false): void {
-    const variableMap = mock.variableMap;
-
-    if (variableMap !== undefined) {
-        mock.setVariable(name, val, secret);
+    if (!mock.variablesMocked) {
+        // variables answer not provided - fallthrough to task implementation.
+        return task.setVariable(name, val, secret);
     }
 
-    // variables answer not provided - fallthrough to task implementation.
-    return task.setVariable(name, val, secret);
+    mock.setVariable(name, val, secret);
 }
 
 function getPathInput(name: string, required?: boolean, check?: boolean): string {

--- a/node/mock-task.ts
+++ b/node/mock-task.ts
@@ -53,8 +53,6 @@ export function loc(key: string, ...args: any[]): string {
 // Input Helpers
 //-----------------------------------------------------
 module.exports.assertAgent = task.assertAgent;
-module.exports.getVariable = task.getVariable;
-module.exports.getVariables = task.getVariables;
 module.exports.setVariable = task.setVariable;
 module.exports.setSecret = task.setSecret;
 module.exports.getTaskVariable = task.getTaskVariable;
@@ -63,6 +61,32 @@ module.exports.getInput = task.getInput;
 module.exports.getBoolInput = task.getBoolInput;
 module.exports.getDelimitedInput = task.getDelimitedInput;
 module.exports.filePathSupplied = task.filePathSupplied;
+
+export function getVariable(name: string): string | undefined  {
+    const variables = mock.getVariableMap();
+
+    if (variables !== undefined) {
+        if (variables[name]) {
+            return variables[name].value;
+        } else {
+            return undefined;
+        }
+    }
+
+    // variables answer not provided - fallthrough to task implementation.
+    return task.getVariable(name);
+}
+
+export function getVariables(): task.VariableInfo[] {
+    const variables = mock.getVariables();
+
+    if (variables !== undefined) {
+        return variables;
+    }
+
+    // variables answer not provided - fallthrough to task implementation.
+    return task.getVariables();
+}
 
 function getPathInput(name: string, required?: boolean, check?: boolean): string {
     var inval = module.exports.getInput(name, required);

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "3.0.2-preview",
+  "version": "3.0.3-preview",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "3.0.2-preview",
+  "version": "3.0.3-preview",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",


### PR DESCRIPTION
Adding variable mocking. To avoid breaking existing unit tests, these functions fall through to the task implementation if `answers.variables` is undefined.

This mocking has parity with the task implementation.

- [x]  Variable names normalized.
- [x] Error thrown for multi-line secrets.