### PR TITLE
Use fs to load file instead of require

### DIFF
--- a/node/internal.ts
+++ b/node/internal.ts
@@ -99,7 +99,7 @@ function _loadLocStrings(resourceFile: string, culture: string): { [key: string]
     } = {};
 
     if (_exist(resourceFile)) {
-        var resourceJson = require(resourceFile);
+        var resourceJson = JSON.parse(fs.readFileSync(resourceFile, { encoding: 'utf-8' }));
         if (resourceJson && resourceJson.hasOwnProperty('messages')) {
             var locResourceJson: any;
             // load up resource resjson for different culture


### PR DESCRIPTION
This has the advantage of easier debugging (because of caching) and allowing us to webpack this lib (currently doesn't work because of dynamic modules).