### PR TITLE
Clear environment after test runs

### DIFF
--- a/node/mock-test.ts
+++ b/node/mock-test.ts
@@ -67,7 +67,7 @@ export class MockTestRunner {
         }
         let spawn = cp.spawnSync(nodePath, [this._testPath]);
         Object.keys(process.env)
-            .filter(key => key.startsWith('INPUT_') || key => key.startsWith('SECRET_') || key => key.startsWith('VSTS_TASKVARIABLE_'))
+            .filter(key => (key.startsWith('INPUT_') || key.startsWith('SECRET_') || key.startsWith('VSTS_TASKVARIABLE_')))
             .forEach(key => delete process.env[key]);
         if (spawn.error) {
             console.error('Running test failed');

--- a/node/mock-test.ts
+++ b/node/mock-test.ts
@@ -67,7 +67,6 @@ export class MockTestRunner {
         }
         let spawn = cp.spawnSync(nodePath, [this._testPath]);
         Object.keys(process.env)
-        this.substr(position, searchString.length) === searchString
             .filter(key => (key.substr(0, 'INPUT_'.length) === 'INPUT_' ||
                             key.substr(0, 'SECRET_'.length) === 'SECRET_' ||
                             key.substr(0, 'VSTS_TASKVARIABLE_'.length) === 'VSTS_TASKVARIABLE_'))

--- a/node/mock-test.ts
+++ b/node/mock-test.ts
@@ -67,7 +67,10 @@ export class MockTestRunner {
         }
         let spawn = cp.spawnSync(nodePath, [this._testPath]);
         Object.keys(process.env)
-            .filter(key => (key.startsWith('INPUT_') || key.startsWith('SECRET_') || key.startsWith('VSTS_TASKVARIABLE_')))
+        this.substr(position, searchString.length) === searchString
+            .filter(key => (key.substr(0, 'INPUT_'.length) === 'INPUT_' ||
+                            key.substr(0, 'SECRET_'.length) === 'SECRET_' ||
+                            key.substr(0, 'VSTS_TASKVARIABLE_'.length) === 'VSTS_TASKVARIABLE_'))
             .forEach(key => delete process.env[key]);
         if (spawn.error) {
             console.error('Running test failed');

--- a/node/mock-test.ts
+++ b/node/mock-test.ts
@@ -66,6 +66,9 @@ export class MockTestRunner {
             nodePath = this.getNodePath(nodeVersion);
         }
         let spawn = cp.spawnSync(nodePath, [this._testPath]);
+        Object.keys(process.env)
+            .filter(key => key.startsWith('INPUT_') || key => key.startsWith('SECRET_') || key => key.startsWith('VSTS_TASKVARIABLE_'))
+            .forEach(key => delete process.env[key]);
         if (spawn.error) {
             console.error('Running test failed');
             console.error(spawn.error.message);


### PR DESCRIPTION
This is breaking (which is ok since we're major versioning). It should ensure that if a task author calls `setInput` (or a similar function) for one test it won't affect another test.

Fixes #471 