### PR TITLE
Clean environment after running mocks

### DIFF
--- a/node/mock-test.ts
+++ b/node/mock-test.ts
@@ -66,6 +66,14 @@ export class MockTestRunner {
             nodePath = this.getNodePath(nodeVersion);
         }
         let spawn = cp.spawnSync(nodePath, [this._testPath]);
+
+        // Clean environment
+        Object.keys(process.env)
+            .filter(key => (key.substr(0, 'INPUT_'.length) === 'INPUT_' ||
+                            key.substr(0, 'SECRET_'.length) === 'SECRET_' ||
+                            key.substr(0, 'VSTS_TASKVARIABLE_'.length) === 'VSTS_TASKVARIABLE_'))
+            .forEach(key => delete process.env[key]);
+
         if (spawn.error) {
             console.error('Running test failed');
             console.error(spawn.error.message);


### PR DESCRIPTION
Right now, if you set the input for one test run that carries over to the next one. This disables that behavior

Fixes #471 