### PR TITLE
Dont perform which twice when check is true

### DIFF
--- a/node/internal.ts
+++ b/node/internal.ts
@@ -345,7 +345,10 @@ export function _which(tool: string, check?: boolean): string {
     // recursive when check=true
     if (check) {
         let result: string = _which(tool, false);
-        if (!result) {
+        if (result) {
+            return result;
+        }
+        else {
             if (process.platform == 'win32') {
                 throw new Error(_loc('LIB_WhichNotFound_Win', tool));
             }


### PR DESCRIPTION
Right now, if `check` is true we get the result of `_which(tool, false)` and then don't use that result if the tool is found. We should just short circuit there if the tool is found, rather than basically performing the `_which` an extra time