### PR TITLE
Fixed writeFile to be really synchronous

### DIFF
--- a/node/Strings/resources.resjson/en-US/resources.resjson
+++ b/node/Strings/resources.resjson/en-US/resources.resjson
@@ -30,5 +30,7 @@
   "loc.messages.LIB_OperationFailed": "Failed %s: %s",
   "loc.messages.LIB_UseFirstGlobMatch": "Multiple workspace matches. using first.",
   "loc.messages.LIB_MergeTestResultNotSupported": "Merging test results from multiple files to one test run is not supported on this version of build agent for OSX/Linux, each test result file will be published as a separate test run in VSO/TFS.",
-  "loc.messages.LIB_PlatformNotSupported": "Platform not supported: %s"
+  "loc.messages.LIB_PlatformNotSupported": "Platform not supported: %s",
+  "loc.messages.LIB_FileContentSynced": "Synced the file content to the disk. The content is %s.",
+  "loc.messages.LIB_CantWriteDataToFile": "Can not write data to the file %s. Error: %s"
 }

--- a/node/lib.json
+++ b/node/lib.json
@@ -31,6 +31,8 @@
     "LIB_OperationFailed": "Failed %s: %s",
     "LIB_UseFirstGlobMatch": "Multiple workspace matches. using first.",
     "LIB_MergeTestResultNotSupported": "Merging test results from multiple files to one test run is not supported on this version of build agent for OSX/Linux, each test result file will be published as a separate test run in VSO/TFS.",
-    "LIB_PlatformNotSupported": "Platform not supported: %s"
+    "LIB_PlatformNotSupported": "Platform not supported: %s",
+    "LIB_FileContentSynced": "Synced the file content to the disk. The content is %s.",
+    "LIB_CantWriteDataToFile": "Can not write data to the file %s. Error: %s"
   } 
 }

--- a/node/task.ts
+++ b/node/task.ts
@@ -561,12 +561,28 @@ export interface FsOptions {
 }
 
 export function writeFile(file: string, data: string | Buffer, options?: string | FsOptions) {
-    if(typeof(options) === 'string'){
-        fs.writeFileSync(file, data, {encoding: options});
+    try
+    {
+        const fd = fs.openSync(file, 'w');
+        
+        if(typeof(options) === 'string'){
+            fs.writeFileSync(file, data, {encoding: options});
+        }
+        else {
+            fs.writeFileSync(file, data, options);
+        }
+
+        fs.fsyncSync(fd);
+        debug(loc("LIB_FileContentSynced", data));
+        fs.closeSync(fd);
+
     }
-    else {
-        fs.writeFileSync(file, data, options);
+    catch(e)
+    {
+        Error(loc('LIB_CantWriteDataToFile', file, e));
+        throw e;
     }
+    
 }
 
 /**


### PR DESCRIPTION
This fix is to make the writeFile really synchronous. fs.writeFileSync is not really synchronous.  This was discovered when customers found that even though the kubectl tool was downloaded it wasn't present in the cached location sometimes. This was a varient issue.

We had made a similar change in azure-pipelines-task repo 
PR: https://github.com/microsoft/azure-pipelines-tasks/pull/6545

This fix ensures that after writing the changes are flushed to disk.
More on this writeFileSync issue:
http://www.daveeddy.com/2013/03/26/synchronous-file-io-in-nodejs/