### PR TITLE
Escape % signs

### DIFF
--- a/node/taskcommand.ts
+++ b/node/taskcommand.ts
@@ -91,9 +91,9 @@ export function commandFromString(commandLine) {
 }
 
 function escapedata(s) : string {
-    return s.replace(/\r/g, '%0D')
-            .replace(/\n/g, '%0A')
-            .replace(/%/g, '%25');
+    return s.replace(/%/g, '%25')
+            .replace(/\r/g, '%0D')
+            .replace(/\n/g, '%0A');
 }
 
 function unescapedata(s) : string {
@@ -103,11 +103,11 @@ function unescapedata(s) : string {
 }
 
 function escape(s) : string {
-    return s.replace(/\r/g, '%0D')
+    return s.replace(/%/g, '%25')
+            .replace(/\r/g, '%0D')
             .replace(/\n/g, '%0A')
             .replace(/]/g, '%5D')
-            .replace(/;/g, '%3B')
-            .replace(/%/g, '%25');
+            .replace(/;/g, '%3B');
 }
 
 function unescape(s) : string {

--- a/node/taskcommand.ts
+++ b/node/taskcommand.ts
@@ -92,24 +92,28 @@ export function commandFromString(commandLine) {
 
 function escapedata(s) : string {
     return s.replace(/\r/g, '%0D')
-            .replace(/\n/g, '%0A');
+            .replace(/\n/g, '%0A')
+            .replace(/%/g, '%25');
 }
 
 function unescapedata(s) : string {
     return s.replace(/%0D/g, '\r')
-            .replace(/%0A/g, '\n');
+            .replace(/%0A/g, '\n')
+            .replace(/%25/g, '%');
 }
 
 function escape(s) : string {
     return s.replace(/\r/g, '%0D')
             .replace(/\n/g, '%0A')
             .replace(/]/g, '%5D')
-            .replace(/;/g, '%3B');
+            .replace(/;/g, '%3B')
+            .replace(/%/g, '%25');
 }
 
 function unescape(s) : string {
     return s.replace(/%0D/g, '\r')
             .replace(/%0A/g, '\n')
             .replace(/%5D/g, ']')
-            .replace(/%3B/g, ';');
+            .replace(/%3B/g, ';')
+            .replace(/%25/g, '%');
 }

--- a/node/test/commandtests.ts
+++ b/node/test/commandtests.ts
@@ -68,10 +68,10 @@ describe('Command Tests', function () {
     it ('toString escapes properties', function (done) {
         this.timeout(1000);
 
-        var tc = new tcm.TaskCommand('some.cmd', { foo: ';=\r=\n' }, 'dog');
+        var tc = new tcm.TaskCommand('some.cmd', { foo: ';=\r=\n%3B' }, 'dog');
         assert(tc, 'TaskCommand constructor works');
         var cmdStr = tc.toString();
-        assert.equal(cmdStr, '##vso[some.cmd foo=%3B=%0D=%0A;]dog');
+        assert.equal(cmdStr, '##vso[some.cmd foo=%3B=%0D=%0A%253B;]dog');
         done();
     })
 
@@ -142,11 +142,11 @@ describe('Command Tests', function () {
     })
 
     it ('parses and unescapes properties', function (done) {
-        var cmdStr = '##vso[basic.command foo=%3B=%0D=%0A;]dog';
+        var cmdStr = '##vso[basic.command foo=%3B=%0D=%0A%253B;]dog';
 
         var tc = tcm.commandFromString(cmdStr);
         assert.equal(tc.command, 'basic.command', 'cmd should be basic.command');
-        assert.equal(tc.properties['foo'], ';=\r=\n', 'property should be unescaped')
+        assert.equal(tc.properties['foo'], ';=\r=\n%3B', 'property should be unescaped')
         assert.equal(tc.message, 'dog');
         done();
     })


### PR DESCRIPTION
This will allow users to pass the literal value `%0A` for example and have it get correctly escaped. See #542 for context

Fixes #542 