### PR TITLE
Add link to a typescript task starter template 

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -11,7 +11,7 @@ Cross platform tasks are written in TypeScript.  It is the preferred way to writ
 
 [![NPM version][npm-lib-image]][npm-lib-url]
 
-Step by Step: [Create Task](https://docs.microsoft.com/en-us/azure/devops/extend/develop/add-build-task?view=vsts)  
+Step by Step: [Create Task](https://docs.microsoft.com/en-us/azure/devops/extend/develop/add-build-task?view=vsts) ([starter template](https://github.com/shudv/azure-pipelines-task-template))
 
 Documentation: [TypeScript API](docs/azure-pipelines-task-lib.md), [task JSON schema](https://aka.ms/vsts-tasks.schema.json)
 


### PR DESCRIPTION
**Reason for making this change**

It took me quite a lot of time to setup a working typescript task project. It wasn't obvious how the dependencies are supposed to be packaged within the task. This template has all the build and packaging setup out of the box so that users can get straight to experimenting with their custom logic.

