### PR TITLE
Remove endpoint authorization non-debug logging (SYSTEMVSSCONNECTION exists true)

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "3.1.0-preview",
+  "version": "2.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",

--- a/node/task.ts
+++ b/node/task.ts
@@ -420,7 +420,6 @@ export function getEndpointAuthorization(id: string, optional: boolean): Endpoin
         setResult(TaskResult.Failed, loc('LIB_EndpointAuthNotExist', id));
     }
 
-    console.log(id + ' exists ' + (aval !== null));
     debug(id + ' exists ' + (aval !== null));
 
     var auth: EndpointAuthorization | undefined;


### PR DESCRIPTION
Remove unnecessary logging that results in `SYSTEMVSSCONNECTION exists true` spew in build output.