### PR TITLE
Fixed an issue where output from command without newline was dropped

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",

--- a/node/test/toolrunnertests.ts
+++ b/node/test/toolrunnertests.ts
@@ -921,7 +921,7 @@ describe('Toolrunner Tests', function () {
                 });
         }
     })
-    it('Exec pipe output to another tool, fails if first tool fails', function (done) {
+    it('Exec pipe output to file and another tool, fails if first tool fails', function (done) {
         this.timeout(20000);
 
         var _testExecOptions = <trm.IExecOptions>{
@@ -1011,7 +1011,7 @@ describe('Toolrunner Tests', function () {
                 })
         }
     })
-    it('Exec pipe output to another tool, fails if second tool fails (with file syncs)', function (done) {
+    it('Exec pipe output to file and another tool, fails if second tool fails', function (done) {
         this.timeout(20000);
 
         var _testExecOptions = <trm.IExecOptions>{

--- a/node/test/toolrunnertests.ts
+++ b/node/test/toolrunnertests.ts
@@ -1011,7 +1011,7 @@ describe('Toolrunner Tests', function () {
                 })
         }
     })
-    it('Exec pipe output to another tool, fails if second tool fails', function (done) {
+    it('Exec pipe output to another tool, fails if second tool fails (with file syncs)', function (done) {
         this.timeout(20000);
 
         var _testExecOptions = <trm.IExecOptions>{

--- a/node/toolrunner.ts
+++ b/node/toolrunner.ts
@@ -17,9 +17,6 @@ export interface IExecOptions extends IExecSyncOptions {
 
     /** optional.  defaults to failing on non zero.  ignore will not fail leaving it up to the caller */
     ignoreReturnCode?: boolean;
-
-    /** optional. force flush of stdout. defaults to false */
-    forceFlushStdOut?: boolean;
 }
 
 /**
@@ -806,13 +803,11 @@ export class ToolRunner extends events.EventEmitter {
         // it is possible for the child process to end its last line without a new line.
         // because stdout is buffered, this causes the last line to not get sent to the parent
         // stream. Adding this event forces a flush before the child streams are closed.
-        if (optionsNonNull.forceFlushStdOut) {
-            cp.stdout.on('finish', () => {
-                if (!optionsNonNull.silent) {
-                    optionsNonNull.outStream.write(os.EOL);
-                }
-            });
-        }
+        cp.stdout.on('finish', () => {
+            if (!optionsNonNull.silent) {
+                optionsNonNull.outStream.write(os.EOL);
+            }
+        });
 
         var stdbuffer: string = '';
         cp.stdout.on('data', (data: Buffer) => {

--- a/node/toolrunner.ts
+++ b/node/toolrunner.ts
@@ -17,6 +17,9 @@ export interface IExecOptions extends IExecSyncOptions {
 
     /** optional.  defaults to failing on non zero.  ignore will not fail leaving it up to the caller */
     ignoreReturnCode?: boolean;
+
+    /** optional. force flush of stdout. defaults to false */
+    forceFlushStdOut?: boolean;
 }
 
 /**
@@ -803,11 +806,13 @@ export class ToolRunner extends events.EventEmitter {
         // it is possible for the child process to end its last line without a new line.
         // because stdout is buffered, this causes the last line to not get sent to the parent
         // stream. Adding this event forces a flush before the child streams are closed.
-        cp.stdout.on('finish', () => {
-            if (!optionsNonNull.silent) {
-                optionsNonNull.outStream.write(os.EOL);
-            }
-        });
+        if (optionsNonNull.forceFlushStdOut) {
+            cp.stdout.on('finish', () => {
+                if (!optionsNonNull.silent) {
+                    optionsNonNull.outStream.write(os.EOL);
+                }
+            });
+        }
 
         var stdbuffer: string = '';
         cp.stdout.on('data', (data: Buffer) => {


### PR DESCRIPTION
Reported as an issue in the agent:
https://github.com/microsoft/azure-pipelines-agent/issues/2242