### PR TITLE
Added .npmigore file to not include tests in npm package

### DIFF
--- a/node/.npmignore
+++ b/node/.npmignore
@@ -1,0 +1,4 @@
+test
+_build
+_download
+_test


### PR DESCRIPTION
When I ran npm publish, the created package contained test directories which has a task.json which breaks tests in azure-pipelines-task. This excludes those directories from getting in the package.