### PR TITLE
docs: Include required file placement in docs

### DIFF
--- a/powershell/Docs/Consuming.md
+++ b/powershell/Docs/Consuming.md
@@ -42,3 +42,5 @@ MyTask
             [...]
             VstsTaskSdk.psd1
 ```
+
+The `task.json` file and task execution target file `MyTask.ps1` must also be in the root of the task folder, otherwise the task will not be able to locate the `ps_modules` directory at runtime. Having the `MyTask.ps1` execution target file in the root directory was not a requirement of the original `PowerShell` task execution handler, but is for `PowerShell3`.


### PR DESCRIPTION
Previously the task execution target file did not have to be in the task root directory; it could be in a subdirectory and be referenced by the `task.json` file. With the new `PowerShell3` task execution handler, this is no longer allowed as it results in a "file not found" error at runtime.