### PR TITLE
Add missing assertion in single pattern findMatch tests

### DIFF
--- a/node/test/findmatchtests.ts
+++ b/node/test/findmatchtests.ts
@@ -44,6 +44,7 @@ describe('Find and Match Tests', function () {
             path.join(root, 'hello.txt'),
             path.join(root, 'world.txt'),
         ];
+        assert.deepEqual(actual, expected);
 
         done();
     });


### PR DESCRIPTION
Hi! I was investigating a customer issue over at App Center that required some debugging with findMatch. While the error ended up not being related to this task, I did notice a missing test assertion while I was looking into it.

I think this is just an oversight, so here's a quick PR to add it!