### PR TITLE
Allow undefined env var values

### DIFF
--- a/node/toolrunner.ts
+++ b/node/toolrunner.ts
@@ -27,7 +27,7 @@ export interface IExecSyncOptions {
     cwd?: string;
 
     /** optional envvar dictionary.  defaults to current process's env */
-    env?: { [key: string]: string };
+    env?: { [key: string]: string | undefined };
 
     /** optional.  defaults to false */
     silent?: boolean;


### PR DESCRIPTION
While it doesn't make any sense, the typings for `process.env` is:

```ts
    interface ProcessEnv {
        [key: string]: string | undefined;
    }
```

So assigning `process.env` to `IExecSyncOptions.env` in typescript with all typings turned on produces compiler errors (at least when strict null checking is applied).

Without this simple typings adjustment, the following workaround in user code is required:

```ts
function GetFilteredEnv() {
    const result = {};
    const block = process.env;
    for (const key in block) {
        if (block.hasOwnProperty(key)) {
            const value = block[key];
            if (value !== undefined) {
                result[key] = value;
            }
        }
    }
    return result;
}

let options: IExecSyncOptions = { env: GetFilteredEnv() };
```

But with this change it's as simple as:

```ts
let options: IExecSyncOptions = { env: process.env };
```

Which ironically is already what is done *within* this repo, but isn't a problem because the node typings aren't imported so `process.env` is typed as `any`.