### PR TITLE
Handle multiple pipes

### DIFF
--- a/node/docs/azure-pipelines-task-lib.json
+++ b/node/docs/azure-pipelines-task-lib.json
@@ -423,7 +423,7 @@
                   "parameters": [
                     {
                       "name": "tool",
-                      "type": "ToolRunner",
+                      "type": "ToolRunner[]",
                       "optional": false,
                       "documentation": ""
                     },

--- a/node/docs/azure-pipelines-task-lib.md
+++ b/node/docs/azure-pipelines-task-lib.md
@@ -445,7 +445,7 @@ options | IExecSyncOptions | optional exec options.  See IExecSyncOptions
 Pipe output of exec() to another tool
 @returns {ToolRunner}
 ```javascript
-pipeExecOutputToTool(tool:ToolRunner, file?:string):ToolRunner
+pipeExecOutputToTool(tool:ToolRunner[], file?:string):ToolRunner
 ```
  
 Param | Type | Description

--- a/node/mock-toolrunner.ts
+++ b/node/mock-toolrunner.ts
@@ -47,7 +47,7 @@ export class ToolRunner extends events.EventEmitter {
 
     private toolPath: string;
     private args: string[];
-    private pipeOutputToTool: ToolRunner | undefined;
+    private pipeOutputToTools: ToolRunner[] | undefined;
 
     private _debug(message) {
         debug(message);
@@ -142,8 +142,8 @@ export class ToolRunner extends events.EventEmitter {
         return this;
     }
 
-    public pipeExecOutputToTool(tool: ToolRunner) : ToolRunner {
-        this.pipeOutputToTool = tool;
+    public pipeExecOutputToTool(tools: ToolRunner[]) : ToolRunner {
+        this.pipeOutputToTools = tools;
         return this;
     }
 
@@ -195,14 +195,16 @@ export class ToolRunner extends events.EventEmitter {
         cmdString = this.ignoreTempPath(cmdString);
 
         if (!ops.silent) {
-            if(this.pipeOutputToTool) {
-                var pipeToolArgString = this.pipeOutputToTool.args.join(' ') || '';
-                var pipeToolCmdString = this.ignoreTempPath(this.pipeOutputToTool.toolPath);
-                if(pipeToolArgString) {
-                    pipeToolCmdString += (' ' + pipeToolArgString);
+            if(this.pipeOutputToTools) {
+                for (const tr of this.pipeOutputToTools) {
+                    const pipeToolArgString = tr.args.join(' ') || '';
+                    let pipeToolCmdString = this.ignoreTempPath(tr.toolPath);
+                    if(pipeToolArgString) {
+                        pipeToolCmdString += (' ' + pipeToolArgString);
+                    }
+                    
+                    cmdString += ' | ' + pipeToolCmdString;
                 }
-
-                cmdString += ' | ' + pipeToolCmdString;
             }
 
             ops.outStream.write('[command]' + cmdString + os.EOL);

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -7,8 +7,7 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-      "dev": true
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -33,8 +32,7 @@
     "caseless": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-      "dev": true
+      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -45,7 +43,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
       "integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
@@ -55,8 +52,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "debug": {
       "version": "3.1.0",
@@ -103,7 +99,6 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-2.5.1.tgz",
       "integrity": "sha1-jORHvbW2xXf4pj4/p4BW7Eu02/s=",
-      "dev": true,
       "requires": {
         "caseless": "~0.11.0",
         "concat-stream": "^1.4.6",
@@ -113,8 +108,7 @@
     "http-response-object": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-1.1.0.tgz",
-      "integrity": "sha1-p8TnWq6C87tJBOT0P2FWc7TVGMM=",
-      "dev": true
+      "integrity": "sha1-p8TnWq6C87tJBOT0P2FWc7TVGMM="
     },
     "inflight": {
       "version": "1.0.6",
@@ -129,14 +123,12 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -244,14 +236,12 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-      "dev": true
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "dev": true,
       "requires": {
         "asap": "~2.0.3"
       }
@@ -264,14 +254,12 @@
     "qs": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha1-NJzfbu+J7EXBLX1es/wMhwNDptg=",
-      "dev": true
+      "integrity": "sha1-NJzfbu+J7EXBLX1es/wMhwNDptg="
     },
     "readable-stream": {
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
       "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
-      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -285,8 +273,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
-      "dev": true
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
     },
     "semver": {
       "version": "5.5.0",
@@ -302,7 +289,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -311,7 +297,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-3.0.1.tgz",
       "integrity": "sha1-yqEjWq+Im6UBB2oYNMQ2gwqC+3M=",
-      "dev": true,
       "requires": {
         "concat-stream": "^1.4.7",
         "http-response-object": "^1.0.1",
@@ -322,7 +307,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/then-request/-/then-request-2.2.0.tgz",
       "integrity": "sha1-ZnizL6DKIY/laZgbvYhxtZQGDYE=",
-      "dev": true,
       "requires": {
         "caseless": "~0.11.0",
         "concat-stream": "^1.4.7",
@@ -335,8 +319,7 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
       "version": "3.1.3",
@@ -347,8 +330,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "3.2.1",

--- a/node/test/toolrunnertests.ts
+++ b/node/test/toolrunnertests.ts
@@ -631,7 +631,7 @@ describe('Toolrunner Tests', function () {
                 .arg('line 1')
                 .arg('line 2')
                 .arg('line 3');
-            outputExe.pipeExecOutputToTool(matchExe);
+            outputExe.pipeExecOutputToTool([matchExe]);
 
             var output = '';
             outputExe.on('stdout', (data) => {
@@ -654,7 +654,7 @@ describe('Toolrunner Tests', function () {
 
             var ps = tl.tool(tl.which('ps', true));
             ps.arg('ax');
-            ps.pipeExecOutputToTool(grep);
+            ps.pipeExecOutputToTool([grep]);
 
             var output = '';
             ps.on('stdout', (data) => {
@@ -694,7 +694,7 @@ describe('Toolrunner Tests', function () {
                 .arg('line 1')
                 .arg('line 2')
                 .arg('line 3');
-            outputExe.pipeExecOutputToTool(matchExe);
+            outputExe.pipeExecOutputToTool([matchExe]);
 
             var output = '';
             outputExe.on('stdout', (data) => {
@@ -726,7 +726,7 @@ describe('Toolrunner Tests', function () {
 
             var ps = tl.tool(tl.which('ps', true));
             ps.arg('bad');
-            ps.pipeExecOutputToTool(grep);
+            ps.pipeExecOutputToTool([grep]);
 
             var output = '';
             ps.on('stdout', (data) => {
@@ -777,7 +777,7 @@ describe('Toolrunner Tests', function () {
                 .arg('line 1')
                 .arg('line 2')
                 .arg('line 3');
-            outputExe.pipeExecOutputToTool(matchExe);
+            outputExe.pipeExecOutputToTool([matchExe]);
 
             var output = '';
             outputExe.on('stdout', (data) => {
@@ -816,7 +816,7 @@ describe('Toolrunner Tests', function () {
             var node = tl.tool(tl.which('node', true))
                 .arg('-e')
                 .arg('console.log("line1"); setTimeout(function () { console.log("line2"); }, 200);'); // allow long enough to hook up stdout to stdin
-            node.pipeExecOutputToTool(grep);
+            node.pipeExecOutputToTool([grep]);
 
             var output = '';
             node.on('stdout', (data) => {
@@ -874,7 +874,7 @@ describe('Toolrunner Tests', function () {
                 .arg('line 1')
                 .arg('line 2')
                 .arg('line 3');
-            outputExe.pipeExecOutputToTool(matchExe, testFile);
+            outputExe.pipeExecOutputToTool([matchExe], testFile);
 
             var output = '';
             outputExe.on('stdout', (data) => {
@@ -900,7 +900,7 @@ describe('Toolrunner Tests', function () {
 
             var ps = tl.tool(tl.which('ps', true));
             ps.arg('ax');
-            ps.pipeExecOutputToTool(grep, testFile);
+            ps.pipeExecOutputToTool([grep], testFile);
 
             var output = '';
             ps.on('stdout', (data) => {
@@ -945,7 +945,7 @@ describe('Toolrunner Tests', function () {
                 .arg('line 1')
                 .arg('line 2')
                 .arg('line 3');
-            outputExe.pipeExecOutputToTool(matchExe, testFile);
+            outputExe.pipeExecOutputToTool([matchExe], testFile);
 
             var output = '';
             outputExe.on('stdout', (data) => {
@@ -980,7 +980,7 @@ describe('Toolrunner Tests', function () {
 
             var ps = tl.tool(tl.which('ps', true));
             ps.arg('bad');
-            ps.pipeExecOutputToTool(grep, testFile);
+            ps.pipeExecOutputToTool([grep], testFile);
 
             var output = '';
             ps.on('stdout', (data) => {
@@ -1036,7 +1036,7 @@ describe('Toolrunner Tests', function () {
                 .arg('line 1')
                 .arg('line 2')
                 .arg('line 3');
-            outputExe.pipeExecOutputToTool(matchExe, testFile);
+            outputExe.pipeExecOutputToTool([matchExe], testFile);
 
             var output = '';
             outputExe.on('stdout', (data) => {
@@ -1077,7 +1077,7 @@ describe('Toolrunner Tests', function () {
 
             var ps = tl.tool(tl.which('ps', true));
             ps.arg('ax');
-            ps.pipeExecOutputToTool(grep, testFile);
+            ps.pipeExecOutputToTool([grep], testFile);
 
             var output = '';
             ps.on('stdout', (data) => {
@@ -1804,7 +1804,7 @@ describe('Toolrunner Tests', function () {
             cmdRunner.on('stdout', (data) => {
                 output += data.toString();
             });
-            cmdRunner.pipeExecOutputToTool(exeRunner);
+            cmdRunner.pipeExecOutputToTool([exeRunner]);
             cmdRunner.exec(options)
                 .then(function (code) {
                     assert.equal(code, 0, 'return code should be 0');
@@ -1841,7 +1841,7 @@ describe('Toolrunner Tests', function () {
             cmdRunner.on('stdout', (data) => {
                 output += data.toString();
             });
-            cmdRunner.pipeExecOutputToTool(exeRunner);
+            cmdRunner.pipeExecOutputToTool([exeRunner]);
             cmdRunner.exec(options)
                 .then(function (code) {
                     assert.equal(code, 0, 'return code should be 0');


### PR DESCRIPTION
This is a POC for #617 

This PR allows the lib to handle multiple pipes. I don't know if there is some reason why it was created to support only one pipe but i created this example so we can discuss about it. 

Until now if i run a cmd like `oc describe pod/nodejs-ex-3-xtnqn | grep node | grep kubernetes` it resulted in:
![image](https://user-images.githubusercontent.com/49404737/74018374-1be2ec80-4996-11ea-8fd8-225c60b7bd6f.png)

With this PR the output is:
![image](https://user-images.githubusercontent.com/49404737/74018447-374df780-4996-11ea-8084-d16800f77e93.png)

This is a very simple example but you can see the limitation of just allowing one single pipe.

I edited the code as less as i could waiting to collaborate with you because i had many doubts. I.e if we allow to handle multiple pipes and a filename is passed, which data we should write to the file? The final result after all pipes run or just the first toolrunner's result?

Thank you