### PR TITLE
Update Docs to point to a simple and more clear example 

### DIFF
--- a/powershell/Docs/README.md
+++ b/powershell/Docs/README.md
@@ -6,7 +6,7 @@ The VSTS Task SDK for PowerShell is designed to work with the agent's new PowerS
 ## Reference Examples
 
 The [CustomBuildTask](https://github.com/Angr1st/CustomBuildTask) is a really simple example that you can use as a template.
-If you want to see more complicated but better made examples you can have a look at the [MSBuild Task](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/MSBuildV1/MSBuild.ps1) and [VSBuild Task](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VSBuildV1/VSBuild.ps1).
+If you want to see more complicated but more well made examples you can have a look at the [MSBuild Task](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/MSBuildV1/MSBuild.ps1) and [VSBuild Task](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VSBuildV1/VSBuild.ps1).
 
 ## Documentation
 

--- a/powershell/Docs/README.md
+++ b/powershell/Docs/README.md
@@ -5,7 +5,8 @@ The VSTS Task SDK for PowerShell is designed to work with the agent's new PowerS
 
 ## Reference Examples
 
-The [MSBuild Task](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/MSBuildV1/MSBuild.ps1) and [VSBuild Task](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VSBuildV1/VSBuild.ps1) are good examples.
+The [CustomBuildTask](https://github.com/Angr1st/CustomBuildTask) is a really simple example that you can use as a template.
+If you want to see more complicated but better made example you can have a look at the [MSBuild Task](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/MSBuildV1/MSBuild.ps1) and [VSBuild Task](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VSBuildV1/VSBuild.ps1).
 
 ## Documentation
 

--- a/powershell/Docs/README.md
+++ b/powershell/Docs/README.md
@@ -6,7 +6,7 @@ The VSTS Task SDK for PowerShell is designed to work with the agent's new PowerS
 ## Reference Examples
 
 The [CustomBuildTask](https://github.com/Angr1st/CustomBuildTask) is a really simple example that you can use as a template.
-If you want to see more complicated but better made example you can have a look at the [MSBuild Task](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/MSBuildV1/MSBuild.ps1) and [VSBuild Task](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VSBuildV1/VSBuild.ps1).
+If you want to see more complicated but better made examples you can have a look at the [MSBuild Task](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/MSBuildV1/MSBuild.ps1) and [VSBuild Task](https://github.com/Microsoft/vsts-tasks/blob/master/Tasks/VSBuildV1/VSBuild.ps1).
 
 ## Documentation
 


### PR DESCRIPTION
I personally found the linked build task pretty hard to follow because some of the folder structure was replaced during build time/by some script. I updated my repo to contain a very simple and straightforward example of a build task using the powershell3 task executer. This could be helpful for people with a similar goal than I had. Which was to just package another executable on windows to be run as a build task.