### PR TITLE
Fixed documentation for tr.exec()

### DIFF
--- a/node/docs/samples/toolrunner.src
+++ b/node/docs/samples/toolrunner.src
@@ -5,7 +5,7 @@ import tr = require('azure-pipelines-task-lib/toolrunner');
 try {
     var toolPath = tl.which('atool');
     var atool:tr.ToolRunner = tl.tool(toolPath).arg('--afile').line('arguments');
-    var code: number = await tr.exec();
+    var code: number = await atool.exec();
     console.log('rc=' + code);
 }
 catch (err) {


### PR DESCRIPTION
The previous code example had `tr.exec()` on line 8. However, it should be `atool.exec()`.