### PR TITLE
Added shell property to IExecOptions

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "2.9.3",
+  "version": "2.9.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",

--- a/node/toolrunner.ts
+++ b/node/toolrunner.ts
@@ -40,6 +40,9 @@ export interface IExecSyncOptions {
 
     /** optional. Whether to skip quoting/escaping arguments if needed.  defaults to false. */
     windowsVerbatimArguments?: boolean;
+
+    /** optional. Run command inside of the shell.  Defaults to false. */
+    shell?: boolean;
 }
 
 /**
@@ -480,7 +483,8 @@ export class ToolRunner extends events.EventEmitter {
             silent: options.silent || false,
             failOnStdErr: options.failOnStdErr || false,
             ignoreReturnCode: options.ignoreReturnCode || false,
-            windowsVerbatimArguments: options.windowsVerbatimArguments || false
+            windowsVerbatimArguments: options.windowsVerbatimArguments || false,
+            shell: options.shell || false
         };
         result.outStream = options.outStream || <stream.Writable>process.stdout;
         result.errStream = options.errStream || <stream.Writable>process.stderr;
@@ -492,6 +496,7 @@ export class ToolRunner extends events.EventEmitter {
         let result = <child.SpawnOptions>{};
         result.cwd = options.cwd;
         result.env = options.env;
+        result.shell = options.shell;
         result['windowsVerbatimArguments'] = options.windowsVerbatimArguments || this._isCmdFile();
         return result;
     }
@@ -500,6 +505,7 @@ export class ToolRunner extends events.EventEmitter {
         let result = <child.SpawnSyncOptions>{};
         result.cwd = options.cwd;
         result.env = options.env;
+        result.shell = options.shell;
         result['windowsVerbatimArguments'] = options.windowsVerbatimArguments || this._isCmdFile();
         return result;
     }


### PR DESCRIPTION
Added shell property to IExecOptions to allow this property to be specified in pipelines tasks code. This option allows handling variables in command strings.

Related to the [issue.](https://github.com/microsoft/azure-pipelines-tasks/issues/12848)

These changes are required for the [PR in azure-pipelines-tasks repository](https://github.com/microsoft/azure-pipelines-tasks/pull/12880).