### PR TITLE
Permit getDelimitedInput to split on either a string or a Regexp

### DIFF
--- a/node/task.ts
+++ b/node/task.ts
@@ -256,7 +256,7 @@ export function getBoolInput(name: string, required?: boolean): boolean {
  * @param     required whether input is required.  optional, defaults to false
  * @returns   string[]
  */
-export function getDelimitedInput(name: string, delim: string, required?: boolean): string[] {
+export function getDelimitedInput(name: string, delim: string | RegExp, required?: boolean): string[] {
     let inputVal = getInput(name, required);
     if (!inputVal) {
         return [];

--- a/node/test/inputtests.ts
+++ b/node/test/inputtests.ts
@@ -620,6 +620,18 @@ describe('Input Tests', function () {
 
         done();
     })
+    it('gets delimited input with a Regexp', function (done) {
+        this.timeout(1000);
+
+        var inputValue = 'a,b\nc';
+        process.env['INPUT_DELIM'] = inputValue;
+        im._loadData();
+
+        var outVal = tl.getDelimitedInput(/[,\n]/, ' ', /*required*/false);
+        assert.equal(outVal.length, 3, 'should return array with 3 elements');
+
+        done();
+    })
 
     // getPathInput tests
     it('gets path input value', function (done) {

--- a/node/test/inputtests.ts
+++ b/node/test/inputtests.ts
@@ -627,7 +627,7 @@ describe('Input Tests', function () {
         process.env['INPUT_DELIM'] = inputValue;
         im._loadData();
 
-        var outVal = tl.getDelimitedInput(/[,\n]/, ' ', /*required*/false);
+        var outVal = tl.getDelimitedInput('delim', /[,\n]/, ' ', /*required*/false);
         assert.equal(outVal.length, 3, 'should return array with 3 elements');
 
         done();

--- a/node/test/inputtests.ts
+++ b/node/test/inputtests.ts
@@ -627,7 +627,7 @@ describe('Input Tests', function () {
         process.env['INPUT_DELIM'] = inputValue;
         im._loadData();
 
-        var outVal = tl.getDelimitedInput('delim', /[,\n]/, ' ', /*required*/false);
+        var outVal = tl.getDelimitedInput('delim', /[,\n]/, /*required*/false);
         assert.equal(outVal.length, 3, 'should return array with 3 elements');
 
         done();


### PR DESCRIPTION
Changing the type for `delimiter` to `string | Regexp` in `getDelimitedInput` adds support for multiple delimiters. Supporting multiple delimiters would allow https://github.com/microsoft/azure-pipelines-tasks to which is needed for https://github.com/microsoft/azure-pipelines-tasks/issues/12927 by passing a regular expression to `getDelimitedInput` instead of naively using `split` which breaks when there are no Git tags.
