### PR TITLE
[ToolRunner] Enhanced 'shell' execution option

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,14 +1,13 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "2.9.5",
+  "version": "2.9.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-      "dev": true
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -33,8 +32,7 @@
     "caseless": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-      "dev": true
+      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -45,7 +43,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
       "integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
@@ -55,8 +52,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "debug": {
       "version": "3.1.0",
@@ -103,7 +99,6 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-2.5.1.tgz",
       "integrity": "sha1-jORHvbW2xXf4pj4/p4BW7Eu02/s=",
-      "dev": true,
       "requires": {
         "caseless": "~0.11.0",
         "concat-stream": "^1.4.6",
@@ -113,8 +108,7 @@
     "http-response-object": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-1.1.0.tgz",
-      "integrity": "sha1-p8TnWq6C87tJBOT0P2FWc7TVGMM=",
-      "dev": true
+      "integrity": "sha1-p8TnWq6C87tJBOT0P2FWc7TVGMM="
     },
     "inflight": {
       "version": "1.0.6",
@@ -129,14 +123,12 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -244,14 +236,12 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-      "dev": true
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "dev": true,
       "requires": {
         "asap": "~2.0.3"
       }
@@ -264,14 +254,12 @@
     "qs": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha1-NJzfbu+J7EXBLX1es/wMhwNDptg=",
-      "dev": true
+      "integrity": "sha1-NJzfbu+J7EXBLX1es/wMhwNDptg="
     },
     "readable-stream": {
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
       "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
-      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -285,8 +273,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
-      "dev": true
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
     },
     "semver": {
       "version": "5.5.0",
@@ -302,7 +289,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -311,7 +297,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-3.0.1.tgz",
       "integrity": "sha1-yqEjWq+Im6UBB2oYNMQ2gwqC+3M=",
-      "dev": true,
       "requires": {
         "concat-stream": "^1.4.7",
         "http-response-object": "^1.0.1",
@@ -322,7 +307,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/then-request/-/then-request-2.2.0.tgz",
       "integrity": "sha1-ZnizL6DKIY/laZgbvYhxtZQGDYE=",
-      "dev": true,
       "requires": {
         "caseless": "~0.11.0",
         "concat-stream": "^1.4.7",
@@ -335,8 +319,7 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
       "version": "3.1.3",
@@ -347,8 +330,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "3.2.1",

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "2.9.5",
+  "version": "2.9.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,13 +1,14 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "2.9.6",
+  "version": "2.9.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -32,7 +33,8 @@
     "caseless": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
+      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -43,6 +45,7 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
       "integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
@@ -52,7 +55,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "debug": {
       "version": "3.1.0",
@@ -99,6 +103,7 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-2.5.1.tgz",
       "integrity": "sha1-jORHvbW2xXf4pj4/p4BW7Eu02/s=",
+      "dev": true,
       "requires": {
         "caseless": "~0.11.0",
         "concat-stream": "^1.4.6",
@@ -108,7 +113,8 @@
     "http-response-object": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-1.1.0.tgz",
-      "integrity": "sha1-p8TnWq6C87tJBOT0P2FWc7TVGMM="
+      "integrity": "sha1-p8TnWq6C87tJBOT0P2FWc7TVGMM=",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -123,12 +129,14 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -236,12 +244,14 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
     },
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dev": true,
       "requires": {
         "asap": "~2.0.3"
       }
@@ -254,12 +264,14 @@
     "qs": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha1-NJzfbu+J7EXBLX1es/wMhwNDptg="
+      "integrity": "sha1-NJzfbu+J7EXBLX1es/wMhwNDptg=",
+      "dev": true
     },
     "readable-stream": {
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
       "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -273,7 +285,8 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
+      "dev": true
     },
     "semver": {
       "version": "5.5.0",
@@ -289,6 +302,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -297,6 +311,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-3.0.1.tgz",
       "integrity": "sha1-yqEjWq+Im6UBB2oYNMQ2gwqC+3M=",
+      "dev": true,
       "requires": {
         "concat-stream": "^1.4.7",
         "http-response-object": "^1.0.1",
@@ -307,6 +322,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/then-request/-/then-request-2.2.0.tgz",
       "integrity": "sha1-ZnizL6DKIY/laZgbvYhxtZQGDYE=",
+      "dev": true,
       "requires": {
         "caseless": "~0.11.0",
         "concat-stream": "^1.4.7",
@@ -319,7 +335,8 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
     },
     "typescript": {
       "version": "3.1.3",
@@ -330,7 +347,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "uuid": {
       "version": "3.2.1",

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "2.9.5",
+  "version": "2.9.6",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",

--- a/node/test/toolrunnertests.ts
+++ b/node/test/toolrunnertests.ts
@@ -2224,7 +2224,7 @@ describe('Toolrunner Tests', function () {
                 });
                 statRunner.exec(_testExecOptions).then(function (code) {
                     assert.equal(code, 0, 'return code of stat should be 0');
-                    assert.equal(output, '-TEST1=test value;test -TEST2=/one/two/three -TEST3=out:$TEST');
+                    assert.equal(output, '-TEST1=test value;test -TEST2=/one/two/three -TEST3=out:$TEST\n');
                     done();
                 })
                 .fail(function (err) {

--- a/node/test/toolrunnertests.ts
+++ b/node/test/toolrunnertests.ts
@@ -2097,9 +2097,9 @@ describe('Toolrunner Tests', function () {
                 assert.equal(ret.stdout.trim(), 'args[0]: \'test value\'', 'Command should return \"args[0]: \'test value\'\"');
             }
             else {
-                var ret = tl.execSync('stat', '--format "%n" $TESTPATH', _testExecOptions);
+                var ret = tl.execSync('stat', '$TESTPATH', _testExecOptions);
                 assert.equal(ret.code, 0, 'return code of stat should be 0');
-                assert.equal(ret.stdout.trim(), tempPath, `Command should return \'${tempPath}\'`);
+                assert(ret.stdout.includes(tempPath), `Result should include \'${tempPath}\'`);
             }
     
             assert(ret.stdout && ret.stdout.length > 0, 'should have emitted stdout');
@@ -2127,13 +2127,13 @@ describe('Toolrunner Tests', function () {
             }
             else {
                 let statRunner = tl.tool('stat');
-                statRunner.line('--format "%n" $TESTPATH');
+                statRunner.line('$TESTPATH');
                 statRunner.on('stdout', (data) => {
                     output = data.toString();
                 });
                 statRunner.exec(_testExecOptions).then(function (code) {
                     assert.equal(code, 0, 'return code of stat should be 0');
-                    assert.equal(output.trim(), tempPath, `Command should return \'${tempPath}\'`);
+                    assert(output.includes(tempPath), `Result should include \'${tempPath}\'`);
                     done();
                 })
                 .fail(function (err) {

--- a/node/test/toolrunnertests.ts
+++ b/node/test/toolrunnertests.ts
@@ -1232,6 +1232,7 @@ describe('Toolrunner Tests', function () {
         assert.equal((node as any).args.toString(), '--path,/bin/working folder1', 'should be --path /bin/working folder1');
         done();
     })
+
     if (process.platform != 'win32') {
         it('exec prints [command] (OSX/Linux)', function (done) {
             this.timeout(10000);
@@ -1353,7 +1354,7 @@ describe('Toolrunner Tests', function () {
             // this test validates the quoting that tool runner adds around the tool path
             // when using the windowsVerbatimArguments option. otherwise the target process
             // interprets the args as starting after the first space in the tool path.
-            let exePath = compileArgsExe('print-args exe with spaces.exe');
+            let exePath = compileArgsExe('print args exe with spaces.exe');
             let exeRunner = tl.tool(exePath)
                 .arg('myarg1 myarg2');
             let outStream = testutil.createStringStream();

--- a/node/test/toolrunnertests.ts
+++ b/node/test/toolrunnertests.ts
@@ -2127,7 +2127,7 @@ describe('Toolrunner Tests', function () {
             }
             else {
                 let statRunner = tl.tool('stat');
-                statRunner.line('--format "%n" $TEST');
+                statRunner.line('--format "%n" $TESTPATH');
                 statRunner.on('stdout', (data) => {
                     output = data.toString();
                 });
@@ -2224,7 +2224,7 @@ describe('Toolrunner Tests', function () {
                 });
                 statRunner.exec(_testExecOptions).then(function (code) {
                     assert.equal(code, 0, 'return code of stat should be 0');
-                    assert.equal(output, '-TEST1="test value;test" -TEST2=/one/two/three -TEST3=out:$TEST');
+                    assert.equal(output, '-TEST1=test value;test -TEST2=/one/two/three -TEST3=out:$TEST');
                     done();
                 })
                 .fail(function (err) {

--- a/node/test/toolrunnertests.ts
+++ b/node/test/toolrunnertests.ts
@@ -2146,10 +2146,10 @@ describe('Toolrunner Tests', function () {
             this.timeout(30000);
 
             if (os.platform() === 'win32') {
-                var matchExe = tl.tool(compileMatchExe())
+                const matchExe = tl.tool(compileMatchExe())
                     .arg('0') // exit code
                     .arg('test value'); // match value
-                var outputExe = tl.tool(compileOutputExe())
+                const outputExe = tl.tool(compileOutputExe())
                     .arg('0') // exit code
                     .arg('line 1')
                     .arg('"%WIN_TEST%"')
@@ -2172,14 +2172,14 @@ describe('Toolrunner Tests', function () {
                     });
             }
             else {
-                var grep = tl.tool(tl.which('grep', true));
+                const grep = tl.tool(tl.which('grep', true));
                 grep.arg('$TEST_NODE');
     
-                var ps = tl.tool(tl.which('ps', true));
+                const ps = tl.tool(tl.which('ps', true));
                 ps.arg('ax');
                 ps.pipeExecOutputToTool(grep);
     
-                var output = '';
+                let output = '';
                 ps.on('stdout', (data) => {
                     output += data.toString();
                 });

--- a/node/toolrunner.ts
+++ b/node/toolrunner.ts
@@ -333,6 +333,7 @@ export class ToolRunner extends events.EventEmitter {
                 return this._wrapArg(arg, '"');
             });
         }
+
         return this.args;
     }
 
@@ -636,7 +637,6 @@ export class ToolRunner extends events.EventEmitter {
 
         //start the child process for both tools
         waitingEvents++;
-
         var cpFirst = child.spawn(
             this._getSpawnFileName(optionsNonNull),
             this._getSpawnArgs(optionsNonNull),

--- a/node/toolrunner.ts
+++ b/node/toolrunner.ts
@@ -216,6 +216,20 @@ export class ToolRunner extends events.EventEmitter {
 
     }
 
+    /**
+     * Wraps a path string with double quotes if it's not already wrapped
+     * @returns {string} Path wrapped with double quotes
+     * @param {string} path Input path string
+     */
+    private _wrapWithQuotes(path: string): string {
+        const quotesPattern: RegExp = new RegExp(/^\".+\"$/);
+        const isWrappedWithQuotes: boolean = quotesPattern.test(this.toolPath.trim());
+        if (!isWrappedWithQuotes) {
+            return `"${path}"`;
+        } 
+        return path;
+    }
+
     private _getSpawnFileName(options?: IExecOptions): string {
         if (process.platform == 'win32') {
             if (this._isCmdFile()) {
@@ -223,11 +237,7 @@ export class ToolRunner extends events.EventEmitter {
             }
         }
         if (options && options.shell) {
-            const quotesPattern: RegExp = new RegExp(/^\".+\"$/);
-            const isWrappedWithQuotes: boolean = quotesPattern.test(this.toolPath.trim());
-            if (!isWrappedWithQuotes) {
-                return `"${this.toolPath}"`;
-            }
+            return this._wrapWithQuotes(this.toolPath);
         }
         return this.toolPath;
     }

--- a/node/toolrunner.ts
+++ b/node/toolrunner.ts
@@ -7,7 +7,6 @@ import child = require('child_process');
 import stream = require('stream');
 import im = require('./internal');
 import fs = require('fs');
-import { tool } from './task';
 
 /**
  * Interface for exec options

--- a/node/toolrunner.ts
+++ b/node/toolrunner.ts
@@ -226,6 +226,15 @@ export class ToolRunner extends events.EventEmitter {
         return this.toolPath;
     }
 
+    private _getSpawnFileNameForShell(): string {
+        const spawnFileName: string = this._getSpawnFileName().trim();
+        const isWrappedWithQuotes: boolean = /^\".+\"$/.test(spawnFileName);
+        if (!isWrappedWithQuotes) {
+            return `"${spawnFileName}"`;
+        }
+        return spawnFileName;
+    }
+
     private _getSpawnArgs(options: IExecOptions): string[] {
         if (process.platform == 'win32') {
             if (this._isCmdFile()) {
@@ -543,14 +552,19 @@ export class ToolRunner extends events.EventEmitter {
 
         //start the child process for both tools
         waitingEvents++;
+
+        const spawnFileName: string = optionsNonNull.shell ? this._getSpawnFileNameForShell() : this._getSpawnFileName();
+
         var cpFirst = child.spawn(
-            this._getSpawnFileName(),
+            spawnFileName,
             this._getSpawnArgs(optionsNonNull),
             this._getSpawnOptions(optionsNonNull));
 
         waitingEvents ++;
+
+        const spawnFileNameForNextTool: string = optionsNonNull.shell ? pipeOutputToTool._getSpawnFileNameForShell() : pipeOutputToTool._getSpawnFileName();
         cp = child.spawn(
-            pipeOutputToTool._getSpawnFileName(),
+            spawnFileNameForNextTool,
             pipeOutputToTool._getSpawnArgs(optionsNonNull),
             pipeOutputToTool._getSpawnOptions(optionsNonNull));
 
@@ -812,7 +826,9 @@ export class ToolRunner extends events.EventEmitter {
             this._debug(message);
         });
 
-        let cp = child.spawn(this._getSpawnFileName(), this._getSpawnArgs(optionsNonNull), this._getSpawnOptions(options));
+        const spawnFileName: string = options && options.shell ? this._getSpawnFileNameForShell() : this._getSpawnFileName();
+
+        let cp = child.spawn(spawnFileName, this._getSpawnArgs(optionsNonNull), this._getSpawnOptions(options));
 
         // it is possible for the child process to end its last line without a new line.
         // because stdout is buffered, this causes the last line to not get sent to the parent
@@ -920,7 +936,9 @@ export class ToolRunner extends events.EventEmitter {
             options.outStream!.write(this._getCommandString(options as IExecOptions) + os.EOL);
         }
 
-        var r = child.spawnSync(this._getSpawnFileName(), this._getSpawnArgs(options as IExecOptions), this._getSpawnSyncOptions(options));
+        const spawnFileName: string = options && options.shell ? this._getSpawnFileNameForShell() : this._getSpawnFileName();
+
+        var r = child.spawnSync(spawnFileName, this._getSpawnArgs(options as IExecOptions), this._getSpawnSyncOptions(options));
 
         if (!options.silent && r.stdout && r.stdout.length > 0) {
             options.outStream!.write(r.stdout);

--- a/node/toolrunner.ts
+++ b/node/toolrunner.ts
@@ -75,7 +75,7 @@ export class ToolRunner extends events.EventEmitter {
         this._debug('toolRunner toolPath: ' + toolPath);
     }
 
-    private cmdSpecialChars: string[] = [' ', '\t', '&', '(', ')', '[', ']', '{', '}', '^', '=', ';', '!', '\'', '+', ',', '`', '~', '|', '<', '>', '"'];
+    private readonly cmdSpecialChars: string[] = [' ', '\t', '&', '(', ')', '[', ']', '{', '}', '^', '=', ';', '!', '\'', '+', ',', '`', '~', '|', '<', '>', '"'];
     private toolPath: string;
     private args: string[];
     private pipeOutputToTool: ToolRunner | undefined;

--- a/node/toolrunner.ts
+++ b/node/toolrunner.ts
@@ -396,7 +396,7 @@ export class ToolRunner extends events.EventEmitter {
             specialChars = this.cmdSpecialChars.concat(additionalChars);
         }
         for (let char of arg) {
-            if (specialChars.some(x => x == char)) {
+            if (specialChars.some(x => x === char)) {
                 return true;
             }
         }

--- a/node/toolrunner.ts
+++ b/node/toolrunner.ts
@@ -234,9 +234,9 @@ export class ToolRunner extends events.EventEmitter {
      * @param wrapChar A char to be removed
      */
     private _unwrapArg(arg: string, wrapChar: string): string {
-        if (this._isWrapped(arg, '"')) {
+        if (this._isWrapped(arg, wrapChar)) {
             const pattern = new RegExp(`(^\\\\?${wrapChar})|(\\\\?${wrapChar}$)`, 'g');
-            return arg.replace(pattern, '');
+            return arg.trim().replace(pattern, '');
         }
         return arg;
     }
@@ -336,8 +336,8 @@ export class ToolRunner extends events.EventEmitter {
                     return arg;
                 }
                 // remove wrapping double quotes to avoid escaping
-                arg = this._unwrapArg(arg.trim(), '"');
-                arg = this._escapeChar(arg, '"', "\\");
+                arg = this._unwrapArg(arg, '"');
+                arg = this._escapeChar(arg, '"');
                 return this._wrapArg(arg, '"');
             });
         }
@@ -351,33 +351,19 @@ export class ToolRunner extends events.EventEmitter {
      * @param chars Char should be escaped
      * @param escapePrefix Char which should be used to escape. "\" is used if not specified.
      */
-    private _escapeChar(arg: string, charToEscape: string, escapePrefix?: string): string {
-        const escChar: string = escapePrefix || "\\";
-        let prevChar: string = '';
+    private _escapeChar(arg: string, charToEscape: string): string {
+        const escChar: string = "\\";
         let output: string = '';
+        let charIsEscaped: boolean = false;
         for (const char of arg) {
-            if (char === charToEscape && prevChar !== escChar) {
+            if (char === charToEscape && !charIsEscaped) {
                 output += escChar + char;
             } else {
                 output += char;
             }
-            prevChar = char;
+            charIsEscaped = char === escChar && !charIsEscaped;
         }
         return output;
-    }
-
-    /**
-     * Escape multiple string characters.
-     * @param arg String to escape chars in
-     * @param chars Chars should be escaped
-     * @param escapePrefix Char which should be used to escape. "\" is used if not specified.
-     */
-    private _escapeChars(arg: string, chars: string[], escapePrefix?: string): string {
-        let result: string = arg;
-        for (const char of chars) {
-            result = this._escapeChar(result, char, escapePrefix);
-        }
-        return result;
     }
 
     private _isCmdFile(): boolean {

--- a/node/toolrunner.ts
+++ b/node/toolrunner.ts
@@ -348,8 +348,7 @@ export class ToolRunner extends events.EventEmitter {
     /**
      * Escape specified character.
      * @param arg String to escape char in
-     * @param chars Char should be escaped
-     * @param escapePrefix Char which should be used to escape. "\" is used if not specified.
+     * @param charToEscape Char should be escaped
      */
     private _escapeChar(arg: string, charToEscape: string): string {
         const escChar: string = "\\";

--- a/node/toolrunner.ts
+++ b/node/toolrunner.ts
@@ -223,7 +223,8 @@ export class ToolRunner extends events.EventEmitter {
             }
         }
         if (options && options.shell) {
-            const isWrappedWithQuotes: boolean = /^\".+\"$/.test(this.toolPath.trim());
+            const quotesPattern: RegExp = new RegExp(/^\".+\"$/);
+            const isWrappedWithQuotes: boolean = quotesPattern.test(this.toolPath.trim());
             if (!isWrappedWithQuotes) {
                 return `"${this.toolPath}"`;
             }


### PR DESCRIPTION
Enhancement for #637 

Required to fix issue [#12848](https://github.com/microsoft/azure-pipelines-tasks/issues/12848).
Required for PR [#13099](https://github.com/microsoft/azure-pipelines-tasks/pull/13099)

Applied enhancement for `shell` option to wrap a tool path and arguments with double quotes to ensure that command is handled correctly if it is executed inside shell. The path and arguments are wrapped only if `shell` property of `IExecOptions` object set to true. 
Added tests.