### PR TITLE
Allowing env variables to be set without forcing VSTS_TASKVARIABLE_ prefix

### DIFF
--- a/node/mock-run.ts
+++ b/node/mock-run.ts
@@ -18,13 +18,14 @@ export class TaskMockRunner {
         process.env['INPUT_' + key] = val;
     }
 
-    public setVariableName(name: string, val: string, isSecret?: boolean) {
+    public setVariableName(name: string, val: string, isSecret?: boolean, isTaskVariable?: boolean = true) {
         let key: string = im._getVariableKey(name);
         if (isSecret) {
             process.env['SECRET_' + key] = val;
-        }
-        else {
+        } else if (isTaskVariable) {
             process.env['VSTS_TASKVARIABLE_' + key] = val;
+        } else {
+            process.env[key] = val;
         }
     }
 


### PR DESCRIPTION
I'm currently developing an internal Microsoft ADO task that takes in an output variable from another task. It would be very helpful to be able to insert an output variable within the testing framework as well.