### PR TITLE
Update Sync-Request version in package.json

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -33,7 +33,7 @@
     "semver": "^5.1.0",
     "shelljs": "^0.3.0",
     "uuid": "^3.0.1",
-    "sync-request": "3.0.1"
+    "sync-request": "^3.0.1"
   },
   "devDependencies": {
     "mocha": "5.2.0",


### PR DESCRIPTION
I created a similar PR on azure-pipelines-tasks but that may not be the exact right place. https://github.com/microsoft/azure-pipelines-tasks/pull/13556

Issue #11136 on microsoft/azure-pipelines-tasks points out that sync-request is way more up-to-date than 3.0.1 - Is there any reason not to advance the version for this library? At a minimum changing it to `^3.0.1`, if not something higher?

I personally am experiencing similar issues with this erroring out when being run on a pipeline agent even if my version of package.json has a higher version.