### PR TITLE
Add support for killing child processes with SIGINT signal

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "2.10.1",
+  "version": "2.11.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "2.10.1",
+  "version": "2.11.1",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",

--- a/node/toolrunner.ts
+++ b/node/toolrunner.ts
@@ -1026,9 +1026,9 @@ export class ToolRunner extends events.EventEmitter {
 
     /**
      * Used to close child process by sending SIGNINT signal.
-     * It allows to executed script to have some aditional logic on SIGINT, before exiting.
+     * It allows executed script to have some additional logic on SIGINT, before exiting.
      */
-    public killChildProcess() {
+    public killChildProcess(): void {
         if (this.childProcess) {
             this.childProcess.kill();
         }

--- a/node/toolrunner.ts
+++ b/node/toolrunner.ts
@@ -80,6 +80,7 @@ export class ToolRunner extends events.EventEmitter {
     private args: string[];
     private pipeOutputToTool: ToolRunner | undefined;
     private pipeOutputToFile: string | undefined;
+    private childProcess: child.ChildProcess | undefined;
 
     private _debug(message: string) {
         this.emit('debug', message);
@@ -900,7 +901,7 @@ export class ToolRunner extends events.EventEmitter {
         });
 
         let cp = child.spawn(this._getSpawnFileName(options), this._getSpawnArgs(optionsNonNull), this._getSpawnOptions(options));
-
+        this.childProcess = cp;
         // it is possible for the child process to end its last line without a new line.
         // because stdout is buffered, this causes the last line to not get sent to the parent
         // stream. Adding this event forces a flush before the child streams are closed.
@@ -1021,6 +1022,16 @@ export class ToolRunner extends events.EventEmitter {
         res.stdout = (r.stdout) ? r.stdout.toString() : '';
         res.stderr = (r.stderr) ? r.stderr.toString() : '';
         return res;
+    }
+
+    /**
+     * Used to close child process by sending SIGNINT signal.
+     * It allows to executed script to have some aditional logic on SIGINT, before exiting.
+     */
+    public killChildProcess() {
+        if (this.childProcess) {
+            this.childProcess.kill();
+        }
     }
 }
 


### PR DESCRIPTION
This PR is a part of solution for [issue](https://github.com/microsoft/azure-pipelines-tasks/issues/11468) in azure-pipelines-tasks repo. 

Customer has a problem with getting of SIGINT signals inside his build script that contains some additional logic when pipeline run cancellation  happens. This PR should add support of sending SIGINT signals to child processes to get them the ability to perform a number of operations before closing the process in SIGINT handler.