### PR TITLE
Added parameter to setResourcePath to add posibility to disable warnings thrown

### DIFF
--- a/node/internal.ts
+++ b/node/internal.ts
@@ -140,11 +140,11 @@ function _loadLocStrings(resourceFile: string, culture: string): { [key: string]
 /**
  * Sets the location of the resources json.  This is typically the task.json file.
  * Call once at the beginning of the script before any calls to loc.
- *
  * @param     path      Full path to the json.
+ * @param     ignoreWarnings  Won't throw warnings if path already set.
  * @returns   void
  */
-export function _setResourcePath(path: string): void {
+export function _setResourcePath(path: string, ignoreWarnings: boolean = false): void {
     if (process.env['TASKLIB_INPROC_UNITS']) {
         _resourceFiles = {};
         _libResourceFileLoaded = false;
@@ -166,7 +166,11 @@ export function _setResourcePath(path: string): void {
 
     }
     else {
-        _warning(_loc('LIB_ResourceFileAlreadySet', path));
+        if (ignoreWarnings) {
+            _debug(_loc('LIB_ResourceFileAlreadySet', path));
+        } else {
+            _warning(_loc('LIB_ResourceFileAlreadySet', path));
+        }
     }
 }
 

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "3.0.1-preview",
+  "version": "3.0.2-preview",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "3.0.1-preview",
+  "version": "3.0.2-preview",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",


### PR DESCRIPTION
Added parameter to `setResourcePath` method to add posibility to disable warnings thrown

Related issue:
[#274](https://github.com/microsoft/build-task-team/issues/274)

