### PR TITLE
Specifically forwarding process.env to the child process

### DIFF
--- a/node/mock-test.ts
+++ b/node/mock-test.ts
@@ -65,7 +65,7 @@ export class MockTestRunner {
         if (nodeVersion) {
             nodePath = this.getNodePath(nodeVersion);
         }
-        let spawn = cp.spawnSync(nodePath, [this._testPath]);
+        let spawn = cp.spawnSync(nodePath, [this._testPath], { env: process.env });
 
         // Clean environment
         Object.keys(process.env)


### PR DESCRIPTION
This is to work around the issue with `jest` testing library (and perhaps others), where `Jest` sandboxes `process.env`, this makes it impossible to test azure pipelines tasks using `jest` library.

This change has no functional effect on the code as `process.env` is already a default option when not specified.

Jest issue is documented at https://github.com/facebook/jest/issues/5362