### PR TITLE
Change type of the resultFiles parameter of publish method in TestPublisher class

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "2.11.3",
+  "version": "2.11.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "2.11.3",
+  "version": "2.11.4",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",

--- a/node/task.ts
+++ b/node/task.ts
@@ -1780,7 +1780,7 @@ export class TestPublisher {
         // (A parameter cannot both be optional and have an initializer)
         testRunSystem = testRunSystem || "VSTSTask";
 
-        var properties = <{ [key: string]: string }>{};
+        var properties = <{ [key: string]: string | string[] }>{};
         properties['type'] = this.testRunner;
 
         if (mergeResults) {

--- a/node/task.ts
+++ b/node/task.ts
@@ -1775,7 +1775,7 @@ export class TestPublisher {
     constructor(public testRunner: string) {
     }
 
-    public publish(resultFiles?: string, mergeResults?: string, platform?: string, config?: string, runTitle?: string, publishRunAttachments?: string, testRunSystem?: string) {
+    public publish(resultFiles?: string[], mergeResults?: string, platform?: string, config?: string, runTitle?: string, publishRunAttachments?: string, testRunSystem?: string) {
         // Could have used an initializer, but wanted to avoid reordering parameters when converting to strict null checks
         // (A parameter cannot both be optional and have an initializer)
         testRunSystem = testRunSystem || "VSTSTask";


### PR DESCRIPTION
Parent issue: [364](https://github.com/microsoft/build-task-team/issues/364)

**Description**

We get the following error during the compilation of XcodeV5 task in _azure-pipelines-tasks_ repo using a newer version of _azure-pipelines-task-lib_:

> Argument of type 'string[]' is not assignable to parameter of type 'string'.

![image](https://user-images.githubusercontent.com/16704239/96626865-e502fb80-12c4-11eb-84d7-b064c6db143d.png)

`mathcingTestResultsFiles` has `string[]` type [here](https://github.com/microsoft/azure-pipelines-tasks/blob/1538fd6fdb8efd93539b7fe65b00df900d963c1a/Tasks/XcodeV5/postxcode.ts#L38) as it's the result of `findMatch` [function](https://github.com/microsoft/azure-pipelines-task-lib/blob/cf18a238d0ec500d8e8e86b2ff74f901cc92aec2/node/task.ts#L1501). There are several more tasks with the same behavior in the _azure-pipelines-tasks_ .
So we can use `string[]` type (instead of `string`) for the first parameter of  _publish_ method.