### PR TITLE
move ErrActPref restore to finally

### DIFF
--- a/powershell/VstsTaskSdk/InputFunctions.ps1
+++ b/powershell/VstsTaskSdk/InputFunctions.ps1
@@ -232,8 +232,9 @@ function Get-TaskVariable {
             Get-Value @PSBoundParameters -Description $description -Key $variableKey -Value $item.Value
         }
     } catch {
-        $ErrorActionPreference = $originalErrorActionPreference
         Write-Error $_
+    } finally {
+	$ErrorActionPreference = $originalErrorActionPreference
     }
 }
 


### PR DESCRIPTION
Found a small bug which fails to restore the global error action preference. While the SDK does capture the previous global error action value, it will only reset it if you hit an exception within the Get-VstsTaskVariable logic. 