### PR TITLE
Extend setVariable to allow 'output' variables to be created

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "2.11.4",
+  "version": "2.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "2.11.4",
+  "version": "2.12.0",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",

--- a/node/task.ts
+++ b/node/task.ts
@@ -154,12 +154,13 @@ export function getVariables(): VariableInfo[] {
 /**
  * Sets a variable which will be available to subsequent tasks as well.
  * 
- * @param     name    name of the variable to set
- * @param     val     value to set
- * @param     secret  whether variable is secret.  Multi-line secrets are not allowed.  Optional, defaults to false
+ * @param     name     name of the variable to set
+ * @param     val      value to set
+ * @param     secret   whether variable is secret.  Multi-line secrets are not allowed.  Optional, defaults to false
+ * @param     isOutput whether variable is an output variable.  Optional, defaults to false
  * @returns   void
  */
-export function setVariable(name: string, val: string, secret: boolean = false): void {
+export function setVariable(name: string, val: string, secret: boolean = false, isOutput: boolean = false): void {
     // once a secret always a secret
     let key: string = im._getVariableKey(name);
     if (im._knownVariableMap.hasOwnProperty(key)) {
@@ -184,7 +185,7 @@ export function setVariable(name: string, val: string, secret: boolean = false):
     im._knownVariableMap[key] = <im._KnownVariableInfo>{ name: name, secret: secret };
 
     // write the command
-    command('task.setvariable', { 'variable': name || '', 'issecret': (secret || false).toString() }, varValue);
+    command('task.setvariable', { 'variable': name || '', isOutput: (isOutput || false).toString(), 'issecret': (secret || false).toString() }, varValue);
 }
 
 /**

--- a/node/task.ts
+++ b/node/task.ts
@@ -184,7 +184,7 @@ export function setVariable(name: string, val: string, secret: boolean = false, 
     // store the metadata
     im._knownVariableMap[key] = <im._KnownVariableInfo>{ name: name, secret: secret };
 
-    // write the command
+    // write the setvariable command
     command('task.setvariable', { 'variable': name || '', isOutput: (isOutput || false).toString(), 'issecret': (secret || false).toString() }, varValue);
 }
 

--- a/node/test/commandtests.ts
+++ b/node/test/commandtests.ts
@@ -75,6 +75,16 @@ describe('Command Tests', function () {
         done();
     })
 
+    it ('toString writes isOutput', function (done) {
+        this.timeout(1000);
+
+        var tc = new tcm.TaskCommand('task.setvariable', { variable: 'bar', isOutput: 'true' }, 'dog');
+        assert(tc, 'TaskCommand constructor works');
+        var cmdStr = tc.toString();
+        assert.equal(cmdStr, '##vso[task.setvariable variable=bar;isOutput=true;]dog');
+        done();
+    })
+
     it('handles null properties', function (done) {
         this.timeout(1000);
 

--- a/node/test/inputtests.ts
+++ b/node/test/inputtests.ts
@@ -140,6 +140,15 @@ describe('Input Tests', function () {
 
         done();
     })
+    it('sets and gets an output variable', function (done) {
+        this.timeout(1000);
+
+        tl.setVariable('UnitTestVariable', 'test var value', false, true);
+        let varVal: string = tl.getVariable('UnitTestVariable');
+        assert.equal(varVal, 'test var value');
+
+        done();
+    })
     it('sets and gets a secret variable', function (done) {
         this.timeout(1000);
 


### PR DESCRIPTION
This PR resolves #688 by extending the `setVariable` functionality to support output variables.

As suggested by @chris-codeflow, this is as simple as adding the [`isOutput=true`](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#set-a-multi-job-output-variable) property to the `task.setvariable` logging command.

The change is backwards compatible - it does *not* change the signature of `setVariable`.  Rather it adds a new final parameter named `isOutput`.  When `true` the command generated will feature `isOutput=true`.

Consider: 

```ts
tl.setVariable('foo', 'bar', false, true)
```

This would generate the following:

`##vso[task.setvariable variable=foo;isOutput=true;]bar`

#### Tests

I've added a couple of tests.  However it's been a little difficult since I'm unable to run tests on my Ubuntu laptop.  I have a sense that this may not be Linux related, I think this project may depend upon node 6 which is no longer supported.  This is the error encountered why I typed "npm run test":

```shell
> node make.js test

> tsc --outDir /home/john/src/azure-pipelines-task-lib/node/_build
Downloading file: https://nodejs.org/dist/v6.17.1/node-v6.17.1-linux-x64.tar.gz
/home/john/src/azure-pipelines-task-lib/node/node_modules/sync-request/index.js:27
    throw new Error(res.stderr.toString());
    ^

Error
    at doRequest (/home/john/src/azure-pipelines-task-lib/node/node_modules/sync-request/index.js:27:11)
    at downloadFile (/home/john/src/azure-pipelines-task-lib/node/buildutils.js:79:22)
    at downloadArchive (/home/john/src/azure-pipelines-task-lib/node/buildutils.js:111:27)
    at Object.exports.getExternals (/home/john/src/azure-pipelines-task-lib/node/buildutils.js:44:35)
    at Function.target.test (/home/john/src/azure-pipelines-task-lib/node/make.js:46:16)
    at Object.global.target.<computed> [as test] (/home/john/src/azure-pipelines-task-lib/node/node_modules/shelljs/make.js:28:26)
    at /home/john/src/azure-pipelines-task-lib/node/node_modules/shelljs/make.js:38:27
    at Array.forEach (<anonymous>)
    at Timeout._onTimeout (/home/john/src/azure-pipelines-task-lib/node/node_modules/shelljs/make.js:36:10)
    at listOnTimeout (internal/timers.js:554:17)
```