### PR TITLE
Extend setVariable to allow 'output' variables to be created: apply changes to release/3.x branch

### DIFF
--- a/node/task.ts
+++ b/node/task.ts
@@ -153,13 +153,14 @@ export function getVariables(): VariableInfo[] {
 
 /**
  * Sets a variable which will be available to subsequent tasks as well.
- *
- * @param     name    name of the variable to set
- * @param     val     value to set
- * @param     secret  whether variable is secret.  Multi-line secrets are not allowed.  Optional, defaults to false
+ * 
+ * @param     name     name of the variable to set
+ * @param     val      value to set
+ * @param     secret   whether variable is secret.  Multi-line secrets are not allowed.  Optional, defaults to false
+ * @param     isOutput whether variable is an output variable.  Optional, defaults to false
  * @returns   void
  */
-export function setVariable(name: string, val: string, secret: boolean = false): void {
+export function setVariable(name: string, val: string, secret: boolean = false, isOutput: boolean = false): void {
     // once a secret always a secret
     let key: string = im._getVariableKey(name);
     if (im._knownVariableMap.hasOwnProperty(key)) {
@@ -183,8 +184,8 @@ export function setVariable(name: string, val: string, secret: boolean = false):
     // store the metadata
     im._knownVariableMap[key] = <im._KnownVariableInfo>{ name: name, secret: secret };
 
-    // write the command
-    command('task.setvariable', { 'variable': name || '', 'issecret': (secret || false).toString() }, varValue);
+    // write the setvariable command
+    command('task.setvariable', { 'variable': name || '', isOutput: (isOutput || false).toString(), 'issecret': (secret || false).toString() }, varValue);
 }
 
 /**

--- a/node/test/commandtests.ts
+++ b/node/test/commandtests.ts
@@ -72,6 +72,16 @@ describe('Command Tests', function () {
         done();
     })
 
+    it ('toString writes isOutput', function (done) {
+        this.timeout(1000);
+
+        var tc = new tcm.TaskCommand('task.setvariable', { variable: 'bar', isOutput: 'true' }, 'dog');
+        assert(tc, 'TaskCommand constructor works');
+        var cmdStr = tc.toString();
+        assert.equal(cmdStr, '##vso[task.setvariable variable=bar;isOutput=true;]dog');
+        done();
+    })
+
     it('handles null properties', function (done) {
         this.timeout(1000);
 

--- a/node/test/inputtests.ts
+++ b/node/test/inputtests.ts
@@ -137,6 +137,15 @@ describe('Input Tests', function () {
 
         done();
     })
+    it('sets and gets an output variable', function (done) {
+        this.timeout(1000);
+
+        tl.setVariable('UnitTestVariable', 'test var value', false, true);
+        let varVal: string = tl.getVariable('UnitTestVariable');
+        assert.equal(varVal, 'test var value');
+
+        done();
+    })
     it('sets and gets a secret variable', function (done) {
         this.timeout(1000);
 


### PR DESCRIPTION
This is a follow on to #691 which applies the changes there to the `release/3.x` branch as requested by @damccorm 