### PR TITLE
Updated publish methods' to keep it compatible

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",

--- a/node/task.ts
+++ b/node/task.ts
@@ -1776,12 +1776,12 @@ export class TestPublisher {
     constructor(public testRunner: string) {
     }
 
-    public publish(resultFiles?: string[], mergeResults?: string, platform?: string, config?: string, runTitle?: string, publishRunAttachments?: string, testRunSystem?: string) {
+    public publish(resultFiles?: string | string[], mergeResults?: string, platform?: string, config?: string, runTitle?: string, publishRunAttachments?: string, testRunSystem?: string) {
         // Could have used an initializer, but wanted to avoid reordering parameters when converting to strict null checks
         // (A parameter cannot both be optional and have an initializer)
         testRunSystem = testRunSystem || "VSTSTask";
 
-        var properties = <{ [key: string]: string | string[] }>{};
+        var properties = <{ [key: string]: string }>{};
         properties['type'] = this.testRunner;
 
         if (mergeResults) {
@@ -1805,7 +1805,7 @@ export class TestPublisher {
         }
 
         if (resultFiles) {
-            properties['resultFiles'] = resultFiles;
+            properties['resultFiles'] = Array.isArray(resultFiles) ? resultFiles.join() : resultFiles;
         }
 
         properties['testRunSystem'] = testRunSystem;
@@ -1820,7 +1820,7 @@ export class TestPublisher {
 export class CodeCoveragePublisher {
     constructor() {
     }
-    public publish(codeCoverageTool?: string, summaryFileLocation?: string, reportDirectory?: string, additionalCodeCoverageFiles?: string) {
+    public publish(codeCoverageTool?: string, summaryFileLocation?: string, reportDirectory?: string, additionalCodeCoverageFiles?: string | string[]) {
 
         var properties = <{ [key: string]: string }>{};
 
@@ -1837,7 +1837,7 @@ export class CodeCoveragePublisher {
         }
 
         if (additionalCodeCoverageFiles) {
-            properties['additionalcodecoveragefiles'] = additionalCodeCoverageFiles;
+            properties['additionalcodecoveragefiles'] = Array.isArray(additionalCodeCoverageFiles) ? additionalCodeCoverageFiles.join() : additionalCodeCoverageFiles;
         }
 
         command('codecoverage.publish', properties, "");


### PR DESCRIPTION
Updated publish methods' to keep it compatible with tasks using different argument types.

Related issue (internal): [#356](https://github.com/microsoft/build-task-team/issues/356)

The approach was chosen taking the following case into consideration:

- If an empty string is passed to `publish` method of `CodeCoveragePublisher` class as `additionalCodeCoverageFiles` argument we would get the following result:
`##vso[codecoverage.publish]`

- If we try to pass an empty array we would get:
`##vso[codecoverage.publish additionalcodecoveragefiles=;]`

The approach is to pass a string in any case since it's expected by the `TaskCommand` class.