### PR TITLE
Update mock-test.ts

### DIFF
--- a/node/mock-test.ts
+++ b/node/mock-test.ts
@@ -177,7 +177,7 @@ export class MockTestRunner {
             console.warn('Unable to find task.json, defaulting to use Node 14');
             return 10;
         }
-        const taskJsonContents = fs.readFileSync(taskJsonPath, { encoding: 'utf-8' });
+        const taskJsonContents = fs.readFileSync(taskJsonPath, { encoding: 'utf-8' }).trim();
         const taskJson: object = JSON.parse(taskJsonContents);
 
         let nodeVersionFound = false;

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",


### PR DESCRIPTION
Fixes #699 

Task fails when I try to debug using VS code using the tutorial [here ](https://docs.microsoft.com/en-us/azure/devops/extend/develop/add-build-task?view=azure-devops&viewFallbackFrom=vsts) and it gives a SyntaxError giving this error

![image](https://user-images.githubusercontent.com/8571163/106798905-7b102700-6613-11eb-9bb7-858d7b944c13.png)

and it when looking at what the taskJsonContents starts with it is the byte value of 65279. Adding trim fixes this issue