### PR TITLE
[preview] Added retry logic to the cp() method

### DIFF
--- a/node/Strings/resources.resjson/en-US/resources.resjson
+++ b/node/Strings/resources.resjson/en-US/resources.resjson
@@ -30,5 +30,6 @@
   "loc.messages.LIB_OperationFailed": "Failed %s: %s",
   "loc.messages.LIB_UseFirstGlobMatch": "Multiple workspace matches. using first.",
   "loc.messages.LIB_MergeTestResultNotSupported": "Merging test results from multiple files to one test run is not supported on this version of build agent for OSX/Linux, each test result file will be published as a separate test run in VSO/TFS.",
-  "loc.messages.LIB_PlatformNotSupported": "Platform not supported: %s"
+  "loc.messages.LIB_PlatformNotSupported": "Platform not supported: %s",
+  "loc.messages.LIB_CopyFileFailed": "Error while copying the file. Attempts left: %s"
 }

--- a/node/docs/azure-pipelines-task-lib.md
+++ b/node/docs/azure-pipelines-task-lib.md
@@ -777,7 +777,7 @@ source | string | source path
 dest | string | destination path
 options | string | string \-r, \-f or \-rf for recursive and force 
 continueOnError | boolean | optional. whether to continue on error
-retryCount | number | optional. Retry count to copy the file
+retryCount | number | optional. Retry count to copy the file. It might help to resolve intermittent issues e.g. with UNC target paths on a remote host.
  
 <br/>
 <div id="taskmv">

--- a/node/docs/azure-pipelines-task-lib.md
+++ b/node/docs/azure-pipelines-task-lib.md
@@ -777,6 +777,7 @@ source | string | source path
 dest | string | destination path
 options | string | string \-r, \-f or \-rf for recursive and force 
 continueOnError | boolean | optional. whether to continue on error
+retryCount | number | optional. Retry count to copy the file
  
 <br/>
 <div id="taskmv">

--- a/node/lib.json
+++ b/node/lib.json
@@ -31,6 +31,7 @@
     "LIB_OperationFailed": "Failed %s: %s",
     "LIB_UseFirstGlobMatch": "Multiple workspace matches. using first.",
     "LIB_MergeTestResultNotSupported": "Merging test results from multiple files to one test run is not supported on this version of build agent for OSX/Linux, each test result file will be published as a separate test run in VSO/TFS.",
-    "LIB_PlatformNotSupported": "Platform not supported: %s"
+    "LIB_PlatformNotSupported": "Platform not supported: %s",
+    "LIB_CopyFileFailed": "Error while copying the file. Attempts left: %s"
   } 
 }

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "3.0.6-preview.1",
+  "version": "3.0.6-preview.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "3.0.6-preview.1",
+  "version": "3.0.6-preview.2",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",

--- a/node/task.ts
+++ b/node/task.ts
@@ -753,7 +753,11 @@ export function cp(source: string, dest: string, options?: string, continueOnErr
             break;
         } catch (e) {
             if (retryCount <= 0) {
-                throw e;
+                if (continueOnError) {
+                    warning(e);
+                } else {
+                    throw e;
+                }
             } else {
                 console.log(loc('LIB_CopyFileFailed', retryCount));
                 retryCount--;

--- a/node/task.ts
+++ b/node/task.ts
@@ -739,7 +739,7 @@ export function ls(options: string, paths: string[]): string[] {
  * @param     options    string -r, -f or -rf for recursive and force
  * @param     continueOnError optional. whether to continue on error
  */
-export function cp(source: string, dest: string, options?: string, continueOnError?: boolean): void {
+export function cp(source: string, dest: string, options?: string, continueOnError?: boolean, retryCount: number = 0): void {
     if (options) {
         shell.cp(options, source, dest);
     }
@@ -747,7 +747,20 @@ export function cp(source: string, dest: string, options?: string, continueOnErr
         shell.cp(source, dest);
     }
 
-    _checkShell('cp', continueOnError);
+    try {
+        _checkShell('cp', false);
+    } catch (e) {
+        if (retryCount > 0) {
+            console.log(loc('LIB_CopyFileFailed', retryCount));
+            cp(source, dest, options, continueOnError, retryCount - 1);
+        } else {
+            if (continueOnError) {
+                warning(e);
+            } else {
+                throw e;
+            }
+        }
+    }
 }
 
 /**

--- a/node/task.ts
+++ b/node/task.ts
@@ -741,24 +741,22 @@ export function ls(options: string, paths: string[]): string[] {
  * @param     retryCount optional. Retry count to copy the file
  */
 export function cp(source: string, dest: string, options?: string, continueOnError?: boolean, retryCount: number = 0): void {
-    if (options) {
-        shell.cp(options, source, dest);
-    }
-    else {
-        shell.cp(source, dest);
-    }
-
-    try {
-        _checkShell('cp', false);
-    } catch (e) {
-        if (retryCount > 0) {
-            console.log(loc('LIB_CopyFileFailed', retryCount));
-            cp(source, dest, options, continueOnError, retryCount - 1);
-        } else {
-            if (continueOnError) {
-                warning(e);
-            } else {
+    while (retryCount >= 0) {
+        if (options) {
+            shell.cp(options, source, dest);
+        }
+        else {
+            shell.cp(source, dest);
+        }
+        try {
+            _checkShell('cp', false);
+            break;
+        } catch (e) {
+            if (retryCount <= 0) {
                 throw e;
+            } else {
+                console.log(loc('LIB_CopyFileFailed', retryCount));
+                retryCount--;
             }
         }
     }

--- a/node/task.ts
+++ b/node/task.ts
@@ -738,7 +738,7 @@ export function ls(options: string, paths: string[]): string[] {
  * @param     dest       destination path
  * @param     options    string -r, -f or -rf for recursive and force
  * @param     continueOnError optional. whether to continue on error
- * @param     retryCount optional. Retry count to copy the file
+ * @param     retryCount optional. Retry count to copy the file. It might help to resolve intermittent issues e.g. with UNC target paths on a remote host.
  */
 export function cp(source: string, dest: string, options?: string, continueOnError?: boolean, retryCount: number = 0): void {
     while (retryCount >= 0) {

--- a/node/task.ts
+++ b/node/task.ts
@@ -738,6 +738,7 @@ export function ls(options: string, paths: string[]): string[] {
  * @param     dest       destination path
  * @param     options    string -r, -f or -rf for recursive and force
  * @param     continueOnError optional. whether to continue on error
+ * @param     retryCount optional. Retry count to copy the file
  */
 export function cp(source: string, dest: string, options?: string, continueOnError?: boolean, retryCount: number = 0): void {
     if (options) {

--- a/node/task.ts
+++ b/node/task.ts
@@ -755,6 +755,7 @@ export function cp(source: string, dest: string, options?: string, continueOnErr
             if (retryCount <= 0) {
                 if (continueOnError) {
                     warning(e);
+                    break;
                 } else {
                     throw e;
                 }


### PR DESCRIPTION
Added retry logic to the cp() method to avoid intermittent build fails.

Related work item: [#757](https://github.com/microsoft/build-task-team/issues/757)
[Those changes were also introduced for the 2.x release.](https://github.com/microsoft/azure-pipelines-task-lib/pull/707)

Test examples (these changes are tested with CopyFiles task running on Node 10):
[Successful build](https://dev.azure.com/v-egbryz/TestProject/_build/results?buildId=1618&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=1f0a8695-ceaa-5eb2-5ab8-df326b6acd5f)

[Failed build with retryCount set to 2.](https://dev.azure.com/v-egbryz/TestProject/_build/results?buildId=1616&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=1f0a8695-ceaa-5eb2-5ab8-df326b6acd5f&l=16)
[Failed build with retryCount set to 2 (debug)](https://dev.azure.com/v-egbryz/TestProject/_build/results?buildId=1617&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=1f0a8695-ceaa-5eb2-5ab8-df326b6acd5f&l=84)
[build with retryCount set to 2 (debug, continue on error allowed)](https://dev.azure.com/v-egbryz/TestProject/_build/results?buildId=1619&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=1f0a8695-ceaa-5eb2-5ab8-df326b6acd5f)