### PR TITLE
Applied enhancements for the localization pipeline

### DIFF
--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -2,6 +2,14 @@ name: $(Date:MMddyy)$(Rev:.rrrr)
 
 trigger: none
 
+schedules:
+- cron: 0 8 * * Mon # mm HH DD MM DW
+  displayName: Localization update
+  branches:
+    include: 
+    - Localization
+  always: true
+
 stages:
 - stage: __default
   jobs:
@@ -9,6 +17,11 @@ stages:
     pool:
       vmImage: windows-latest
     steps:
+    - powershell: |
+        $week = (Invoke-WebRequest https://whatsprintis.it -Headers @{"Accept"= "application/json"} | ConvertFrom-Json).week
+        Write-Host "##vso[task.setvariable variable=week]$week"
+      displayName: "Determine the number of the week in the sprint"
+
     - task: OneLocBuild@2
       inputs:
         locProj: 'Localize/LocProject.json'
@@ -22,6 +35,19 @@ stages:
         isAutoCompletePrSelected: false
       env:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    
+    - powershell: |
+        $body = '{"text": "Created agent localization update PR. Someone please approve/merge it. :please-puss-in-boots:"}'
+        Invoke-RestMethod -Uri $(slackUri) -Method Post -Body $body -ContentType 'application/json'
+      displayName: 'Send Slack notification'
+      condition: and(succeeded(), eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule'))
+
+    - powershell: |
+        $buildUrl = "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&_a=summary"
+        $body = '{"text": "Something went wrong while creating agent localization update PR. Build: ' + $buildUrl + '"}'
+        Invoke-RestMethod -Uri $(slackUri) -Method Post -Body $body -ContentType 'application/json'
+      displayName: 'Send Slack notification'
+      condition: and(failed(), eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule'))
 
     - task: PublishBuildArtifacts@1
       displayName: 'Publish Artifact: drop'

--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -39,14 +39,14 @@ stages:
     - powershell: |
         $body = '{"text": "Created task-lib localization update PR. Someone please approve/merge it. :please-puss-in-boots:"}'
         Invoke-RestMethod -Uri $(slackUri) -Method Post -Body $body -ContentType 'application/json'
-      displayName: 'Send Slack notification'
+      displayName: 'Send Slack notification about PR opened'
       condition: and(succeeded(), eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule'))
 
     - powershell: |
         $buildUrl = "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&_a=summary"
         $body = '{"text": "Something went wrong while creating task-lib localization update PR. Build: ' + $buildUrl + '"}'
         Invoke-RestMethod -Uri $(slackUri) -Method Post -Body $body -ContentType 'application/json'
-      displayName: 'Send Slack notification'
+      displayName: 'Send Slack notification about error'
       condition: and(failed(), eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule'))
 
     - task: PublishBuildArtifacts@1

--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -17,10 +17,23 @@ stages:
     pool:
       vmImage: windows-latest
     steps:
+    - checkout: self
+      persistCredentials: true
+      
     - powershell: |
-        $week = (Invoke-WebRequest https://whatsprintis.it -Headers @{"Accept"= "application/json"} | ConvertFrom-Json).week
-        Write-Host "##vso[task.setvariable variable=week]$week"
-      displayName: "Determine the number of the week in the sprint"
+        $sprintInfo = Invoke-WebRequest https://whatsprintis.it -Headers @{"Accept"= "application/json"} | ConvertFrom-Json
+        Write-Host "##vso[task.setvariable variable=week]$($sprintInfo.week)"
+        Write-Host "##vso[task.setvariable variable=sprint]$($sprintInfo.sprint)"
+      displayName: "Determine the number of the week in the sprint and sprint number"
+
+    - powershell: |
+        git config --global user.email "$(github_email)"
+        git config --global user.name "$(username)"
+        git checkout -b Localization origin/Localization
+        git merge origin/master
+        git push origin Localization
+      displayName: "Sync with master branch"
+      condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
 
     - task: OneLocBuild@2
       inputs:
@@ -32,23 +45,54 @@ stages:
         repoType: 'gitHub'
         prSourceBranchPrefix: 'Localize'
         gitHubPatVariable: '$(GitHubPAT)'
-        isAutoCompletePrSelected: false
+        isAutoCompletePrSelected: true
       env:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+      condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+
+    - powershell: |
+        $date= Get-Date -Format "MMddyyyy"
+        $updateBranch="Localization-update_$date"
+        echo "##vso[task.setvariable variable=updateBranch]$updateBranch"
+
+        git checkout -b $updateBranch
+
+        Remove-Item -Recurse -Force Localize
+
+        git add -A
+        git commit -m "Removing Localize folder"
+        git push origin $updateBranch
+      displayName: Create and push localization update branch
+      condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+    
+    - task: PowerShell@2
+      inputs:
+        filePath: 'open-pullrequest.ps1'
+        arguments: "-SourceBranch $(updateBranch)"
+        failOnStderr: true
+      env:
+        GH_TOKEN: '$(GitHubPAT)'
+      displayName: Open a PR
+      condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
     
     - powershell: |
-        $body = '{"text": "Created task-lib localization update PR. Someone please approve/merge it. :please-puss-in-boots:"}'
+        $message="Created task-lib localization update PR. Someone please approve/merge it. :please-puss-in-boots: $env:PR_LINK"
+        $body = [PSCustomObject]@{
+          text = $message
+        } | ConvertTo-Json
+
         Invoke-RestMethod -Uri $(slackUri) -Method Post -Body $body -ContentType 'application/json'
       displayName: 'Send Slack notification about PR opened'
-      condition: and(succeeded(), eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule'))
+      condition: and(failed(), eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule'))
 
     - powershell: |
         $buildUrl = "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&_a=summary"
-        $body = '{"text": "Something went wrong while creating task-lib localization update PR. Build: ' + $buildUrl + '"}'
+        $message="Something went wrong while creating task-lib localization update PR. Build: $buildUrl"
+        $body = [PSCustomObject]@{
+          text = $message
+        } | ConvertTo-Json
+
         Invoke-RestMethod -Uri $(slackUri) -Method Post -Body $body -ContentType 'application/json'
       displayName: 'Send Slack notification about error'
       condition: and(failed(), eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule'))
-
-    - task: PublishBuildArtifacts@1
-      displayName: 'Publish Artifact: drop'
 

--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -37,14 +37,14 @@ stages:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     
     - powershell: |
-        $body = '{"text": "Created agent localization update PR. Someone please approve/merge it. :please-puss-in-boots:"}'
+        $body = '{"text": "Created task-lib localization update PR. Someone please approve/merge it. :please-puss-in-boots:"}'
         Invoke-RestMethod -Uri $(slackUri) -Method Post -Body $body -ContentType 'application/json'
       displayName: 'Send Slack notification'
       condition: and(succeeded(), eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule'))
 
     - powershell: |
         $buildUrl = "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&_a=summary"
-        $body = '{"text": "Something went wrong while creating agent localization update PR. Build: ' + $buildUrl + '"}'
+        $body = '{"text": "Something went wrong while creating task-lib localization update PR. Build: ' + $buildUrl + '"}'
         Invoke-RestMethod -Uri $(slackUri) -Method Post -Body $body -ContentType 'application/json'
       displayName: 'Send Slack notification'
       condition: and(failed(), eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule'))

--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -13,7 +13,7 @@ schedules:
 stages:
 - stage: __default
   jobs:
-  - job: Job1
+  - job: LocalizationUpdate
     pool:
       vmImage: windows-latest
     steps:

--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -14,6 +14,7 @@ stages:
 - stage: __default
   jobs:
   - job: LocalizationUpdate
+    displayName: 'Update localization'
     pool:
       vmImage: windows-latest
     steps:
@@ -46,6 +47,7 @@ stages:
         prSourceBranchPrefix: 'Localize'
         gitHubPatVariable: '$(GitHubPAT)'
         isAutoCompletePrSelected: true
+        gitHubPrMergeMethod: 'squash'
       env:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
@@ -83,7 +85,7 @@ stages:
 
         Invoke-RestMethod -Uri $(slackUri) -Method Post -Body $body -ContentType 'application/json'
       displayName: 'Send Slack notification about PR opened'
-      condition: and(failed(), eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule'))
+      condition: and(succeeded(), eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule'))
 
     - powershell: |
         $buildUrl = "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&_a=summary"

--- a/open-pullrequest.ps1
+++ b/open-pullrequest.ps1
@@ -1,0 +1,24 @@
+param(
+    [Parameter(Mandatory)]
+    [string]
+    $SourceBranch
+) 
+
+function Get-PullRequest() {
+    $prInfo = (gh api -X GET repos/:owner/:repo/pulls -F head=":owner:$SourceBranch" -f state=open -f base=master | ConvertFrom-Json)
+    return $prInfo.html_url
+}
+
+$openedPR=Get-PullRequest
+
+if ($openedPR.length -ne 0) {
+    throw "A PR from $SourceBranch to master already exists."
+}
+
+$buildUrl = "$env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI$env:SYSTEM_TEAMPROJECT/_build/results?buildId=$env:BUILD_BUILDID&_a=summary"
+$body = "This PR was auto-generated with [the localization pipeline build]($buildUrl)."
+
+gh pr create --head $SourceBranch --title 'Localization update' --body $body
+
+# Getting a link to the opened PR
+$env:PR_LINK = Get-PullRequest


### PR DESCRIPTION
**Task name**: Localization pipeline definition

**Description**: 
Added schedule trigger to run the localization pipeline on the third week of a sprint on Mondays at 8 a.m. UTC,
Added Slack notifications about successful and failed builds.
Added a script that automatically bumps tasks and common packages versions.
Added a script that creates a PR to the master branch with localization updates.

The pipeline is going to have the following flow:
Checkout Localization branch -> merge master into Localization and push changes -> OneLocBuild task gathers localization strings and commits them (auto-merge a PR) to the Localization -> create a new branch with localization updates -> open a PR to the master branch.

**Documentation changes required:** No

**Added unit tests:** No

**Attached related issue:** [#876](https://github.com/microsoft/build-task-team/issues/876)