### PR TITLE
Allow mirror URL to be set for NodeJS downloads

### DIFF
--- a/node/buildutils.js
+++ b/node/buildutils.js
@@ -33,7 +33,8 @@ exports.getExternals = function () {
 
     // download the same version of node used by the agent
     // and add node to the PATH
-    var nodeUrl = 'https://nodejs.org/dist';
+    var nodeUrl = process.env['TASK_NODE_URL'] || 'https://nodejs.org/dist';
+    nodeUrl = nodeUrl.replace(/\/$/, '');  // ensure there is no trailing slash on the base URL
     var nodeVersion = 'v10.23.0';
     switch (platform) {
         case 'darwin':

--- a/node/mock-test.ts
+++ b/node/mock-test.ts
@@ -229,7 +229,8 @@ export class MockTestRunner {
     // Downloads the specified node version to the download destination. Returns a path to node.exe
     private downloadNode(nodeVersion: string, downloadDestination: string): string {
         shelljs.rm('-rf', downloadDestination);
-        const nodeUrl: string = 'https://nodejs.org/dist';
+        let nodeUrl: string = process.env['TASK_NODE_URL'] || 'https://nodejs.org/dist';
+        nodeUrl = nodeUrl.replace(/\/$/, '');  // ensure there is no trailing slash on the base URL
         let downloadPath = '';
         switch (this.getPlatform()) {
             case 'darwin':


### PR DESCRIPTION
## Testing

The existing tests fail completely without this change, if you try to run them where nodejs.org is not visible (e.g. behind a corporate proxy).

With this change the tests all pass, assuming you set `TASK_NODE_URL` to a mirror URL.

Closes issue #718