### PR TITLE
Fixed localization pipeline issue with already localized strings replaced

### DIFF
--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -52,6 +52,10 @@ stages:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
 
+    - task: PublishBuildArtifacts@1
+      condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+      displayName: 'Publish an artifact'
+      
     - powershell: |
         $date= Get-Date -Format "MMddyyyy"
         $updateBranch="Localization-update_$date"

--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -55,7 +55,7 @@ stages:
     - task: PublishBuildArtifacts@1
       condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
       displayName: 'Publish an artifact'
-      
+
     - powershell: |
         $date= Get-Date -Format "MMddyyyy"
         $updateBranch="Localization-update_$date"
@@ -101,4 +101,3 @@ stages:
         Invoke-RestMethod -Uri $(slackUri) -Method Post -Body $body -ContentType 'application/json'
       displayName: 'Send Slack notification about error'
       condition: and(failed(), eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule'))
-


### PR DESCRIPTION
Added artifact publishing step to the localization pipeline. This step fixes the issue with unrecognized localized strings.

**Attached related issue:** [#915](https://github.com/microsoft/build-task-team/issues/915)