### PR TITLE
Update to use agent-supported version of escaping

### DIFF
--- a/node/taskcommand.ts
+++ b/node/taskcommand.ts
@@ -91,7 +91,7 @@ export function commandFromString(commandLine) {
 }
 
 function escapedata(s) : string {
-    return s.replace(/%/g, '%25')
+    return s.replace(/%/g, '%AZP25')
             .replace(/\r/g, '%0D')
             .replace(/\n/g, '%0A');
 }
@@ -99,11 +99,11 @@ function escapedata(s) : string {
 function unescapedata(s) : string {
     return s.replace(/%0D/g, '\r')
             .replace(/%0A/g, '\n')
-            .replace(/%25/g, '%');
+            .replace(/%AZP25/g, '%');
 }
 
 function escape(s) : string {
-    return s.replace(/%/g, '%25')
+    return s.replace(/%/g, '%AZP25')
             .replace(/\r/g, '%0D')
             .replace(/\n/g, '%0A')
             .replace(/]/g, '%5D')
@@ -115,5 +115,5 @@ function unescape(s) : string {
             .replace(/%0A/g, '\n')
             .replace(/%5D/g, ']')
             .replace(/%3B/g, ';')
-            .replace(/%25/g, '%');
+            .replace(/%AZP25/g, '%');
 }

--- a/node/test/commandtests.ts
+++ b/node/test/commandtests.ts
@@ -68,7 +68,7 @@ describe('Command Tests', function () {
         var tc = new tcm.TaskCommand('some.cmd', { foo: ';=\r=\n%3B' }, 'dog');
         assert(tc, 'TaskCommand constructor works');
         var cmdStr = tc.toString();
-        assert.equal(cmdStr, '##vso[some.cmd foo=%3B=%0D=%0A%253B;]dog');
+        assert.equal(cmdStr, '##vso[some.cmd foo=%3B=%0D=%0A%AZP253B;]dog');
         done();
     })
 
@@ -149,7 +149,7 @@ describe('Command Tests', function () {
     })
 
     it ('parses and unescapes properties', function (done) {
-        var cmdStr = '##vso[basic.command foo=%3B=%0D=%0A%253B;]dog';
+        var cmdStr = '##vso[basic.command foo=%3B=%0D=%0A%AZP253B;]dog';
 
         var tc = tcm.commandFromString(cmdStr);
         assert.equal(tc.command, 'basic.command', 'cmd should be basic.command');


### PR DESCRIPTION
We switched this to %AZP25 in the agent repo and turned it on a month ago - https://github.com/microsoft/azure-pipelines-agent/pull/3303

We should make that switch in the task-lib as well now so that when we encode values they automatically get decoded by the agent