### PR TITLE
retry realpathSync

### DIFF
--- a/node/task.ts
+++ b/node/task.ts
@@ -906,7 +906,14 @@ export function find(findPath: string, options?: FindOptions): string[] {
 
                 if (options.followSymbolicLinks) {
                     // get the realpath
-                    let realPath: string = fs.realpathSync(item.path);
+                    let realPath: string;
+                    try {
+                        realPath = fs.realpathSync(item.path);
+                    } 
+                    catch {
+                        // retry once in case of failure
+                        realPath = fs.realpathSync(item.path);
+                    }
 
                     // fixup the traversal chain to match the item level
                     while (traversalChain.length >= item.level) {


### PR DESCRIPTION
This is a fix/workaround for https://github.com/microsoft/azure-pipelines-tasks/issues/14789 , where `fs.realpathSync` seems to fail in the first try for a NetApp SnapMirror Volume.

Please note that a new release of `azure-pipelines-task-lib` is required to be integrated in the `azure-pipelines-tasks DeleteFiles task` before the original issue can be fully resolved.