### PR TITLE
fix bug with escaped quotes in toolrunner _argStringToArray

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",

--- a/node/test/toolrunnertests.ts
+++ b/node/test/toolrunnertests.ts
@@ -1234,7 +1234,6 @@ describe('Toolrunner Tests', function () {
         var node = tl.tool(tl.which('node', true));
         node.line('-TEST="escaped\\\"quotes" -x');
         node.arg('-y');
-        console.log((node as any).args.toString())
         assert.equal((node as any).args.length, 3, 'should have 3 args');
         assert.equal((node as any).args.toString(), '-TEST=escaped"quotes,-x,-y', 'should be -TEST=escaped"quotes,-x,-y');
         done();        

--- a/node/test/toolrunnertests.ts
+++ b/node/test/toolrunnertests.ts
@@ -1236,7 +1236,7 @@ describe('Toolrunner Tests', function () {
         node.arg('-y');
         console.log((node as any).args.toString())
         assert.equal((node as any).args.length, 3, 'should have 3 args');
-        assert.equal((node as any).args.toString(), '-TEST=escaped"quotes,-x,-y', 'should be -TEST=escaped"quotes');
+        assert.equal((node as any).args.toString(), '-TEST=escaped"quotes,-x,-y', 'should be -TEST=escaped"quotes,-x,-y');
         done();        
     })
     if (process.platform != 'win32') {

--- a/node/test/toolrunnertests.ts
+++ b/node/test/toolrunnertests.ts
@@ -1229,7 +1229,16 @@ describe('Toolrunner Tests', function () {
         assert.equal((node as any).args.toString(), '--path,/bin/working folder1', 'should be --path /bin/working folder1');
         done();
     })
-
+    it('handles escaped quotes', function (done) {
+        this.timeout(10000);
+        var node = tl.tool(tl.which('node', true));
+        node.line('-TEST="escaped\\\"quotes" -x');
+        node.arg('-y');
+        console.log((node as any).args.toString())
+        assert.equal((node as any).args.length, 3, 'should have 3 args');
+        assert.equal((node as any).args.toString(), '-TEST=escaped"quotes,-x,-y', 'should be -TEST=escaped"quotes');
+        done();        
+    })
     if (process.platform != 'win32') {
         it('exec prints [command] (OSX/Linux)', function (done) {
             this.timeout(10000);

--- a/node/toolrunner.ts
+++ b/node/toolrunner.ts
@@ -96,8 +96,8 @@ export class ToolRunner extends events.EventEmitter {
 
         var append = function (c: string) {
             // we only escape double quotes.
-            if (escaped){
-                if(c !== '"') {
+            if (escaped) {
+                if (c !== '"') {
                     arg += '\\';
                 } else {
                     arg.slice(0, -1);         

--- a/node/toolrunner.ts
+++ b/node/toolrunner.ts
@@ -96,10 +96,13 @@ export class ToolRunner extends events.EventEmitter {
 
         var append = function (c: string) {
             // we only escape double quotes.
-            if (escaped && c !== '"') {
-                arg += '\\';
+            if (escaped){
+                if(c !== '"') {
+                    arg += '\\';
+                } else {
+                    arg.slice(0, -1);         
+                }
             }
-
             arg += c;
             escaped = false;
         }


### PR DESCRIPTION
fix bug with  escaped quotes in toolrunner _argStringToArray

for issue [#648 ](https://github.com/microsoft/azure-pipelines-task-lib/issues/648)

1. If we try passing quotes as a value even that is being eaten up by task-lib
Input: `-- TestRunParameters.Parameter(name=paramName,value=argwith"aquote)`
Output `-- TestRunParameters.Parameter(name=paramName,value=argwithaquote)`

2. If we **use backslash** then the quote doesn't is eaten up.
Input: `-- TestRunParameters.Parameter(name=paramName,value=argwith\"aquote)`
Output `-- TestRunParameters.Parameter(name=paramName,value=argwith"aquote)`

3. If we **use backslash** then the quote doesn't is eaten up.
Input: ` -- TestRunParameters.Parameter(name=\"EdiStagingFunctionsKey\",value=\"key2\")`
Output: `TestRunParameters.Parameter(name="EdiStagingFunctionsKey",value="key2")`