### PR TITLE
Skipping the file if it was not found

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",

--- a/node/task.ts
+++ b/node/task.ts
@@ -897,6 +897,10 @@ export function find(findPath: string, options?: FindOptions): string[] {
                 }
             }
             else {
+                if (!fs.existsSync(item.path)) {
+                    debug(`File ${item.path} has not been found and will be ignored.`);
+                    continue;
+                }
                 // use lstat (not following symlinks)
                 stats = fs.lstatSync(item.path);
             }

--- a/node/task.ts
+++ b/node/task.ts
@@ -898,7 +898,7 @@ export function find(findPath: string, options?: FindOptions): string[] {
             }
             else {
                 if (!fs.existsSync(item.path)) {
-                    debug(`File "${item.path}" has not been found and will be skipped.`);
+                    debug(`File "${item.path}" seems to be removed during find operation execution - so skipping it.`);
                     continue;
                 }
                 // use lstat (not following symlinks)

--- a/node/task.ts
+++ b/node/task.ts
@@ -898,7 +898,7 @@ export function find(findPath: string, options?: FindOptions): string[] {
             }
             else {
                 if (!fs.existsSync(item.path)) {
-                    debug(`File ${item.path} has not been found and will be skipped.`);
+                    debug(`File "${item.path}" has not been found and will be skipped.`);
                     continue;
                 }
                 // use lstat (not following symlinks)

--- a/node/task.ts
+++ b/node/task.ts
@@ -898,7 +898,7 @@ export function find(findPath: string, options?: FindOptions): string[] {
             }
             else {
                 if (!fs.existsSync(item.path)) {
-                    debug(`File ${item.path} has not been found and will be ignored.`);
+                    debug(`File ${item.path} has not been found and will be skipped.`);
                     continue;
                 }
                 // use lstat (not following symlinks)

--- a/node/task.ts
+++ b/node/task.ts
@@ -857,6 +857,10 @@ export function find(findPath: string, options?: FindOptions): string[] {
         while (stack.length) {
             // pop the next item and push to the result array
             let item = stack.pop()!; // non-null because `stack.length` was truthy
+            if (!fs.existsSync(item.path)) {
+                debug(`File "${item.path}" seems to be removed during find operation execution - so skipping it.`);
+                continue;
+            }
             result.push(item.path);
 
             // stat the item.  the stat info is used further below to determine whether to traverse deeper
@@ -897,10 +901,6 @@ export function find(findPath: string, options?: FindOptions): string[] {
                 }
             }
             else {
-                if (!fs.existsSync(item.path)) {
-                    debug(`File "${item.path}" seems to be removed during find operation execution - so skipping it.`);
-                    continue;
-                }
                 // use lstat (not following symlinks)
                 stats = fs.lstatSync(item.path);
             }


### PR DESCRIPTION
**Description**: occasionally the `find` function fails with the error `Failed find: ENOENT: no such file or directory`. The reason is that the `fs.lstatSync` method applies to a file that already was deleted. So we should check a file presence and skip it if it does not exist.

**Changelog**: `node/task.ts` — the `find` function — checking a file presence added.

[Related issue](https://github.com/microsoft/azure-pipelines-tasks/issues/14816)