### PR TITLE
Revert "Skipping the file if it was not found"

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "3.1.5",
+  "version": "3.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "3.1.5",
+  "version": "3.1.4",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",

--- a/node/task.ts
+++ b/node/task.ts
@@ -857,10 +857,6 @@ export function find(findPath: string, options?: FindOptions): string[] {
         while (stack.length) {
             // pop the next item and push to the result array
             let item = stack.pop()!; // non-null because `stack.length` was truthy
-            if (!fs.existsSync(item.path)) {
-                debug(`File "${item.path}" seems to be removed during find operation execution - so skipping it.`);
-                continue;
-            }
             result.push(item.path);
 
             // stat the item.  the stat info is used further below to determine whether to traverse deeper


### PR DESCRIPTION
Reverts microsoft/azure-pipelines-task-lib#774

Changes in [this pull request](https://github.com/microsoft/azure-pipelines-task-lib/pull/774) affected the CI for Linux and macOS (Dir Operation Tests) in spite of manual testing passed successfully so we should revert it and investigate why the checks fail.