### PR TITLE
#716 - fix issue - "How can I mock a pipeline variable in my tests"

### DIFF
--- a/node/mock-answer.ts
+++ b/node/mock-answer.ts
@@ -20,6 +20,7 @@ export interface TaskLibAnswers {
     rmRF?: { [key: string]: { success: boolean } },
     stats?: { [key: string]: any }, // Can't use `fs.Stats` as most existing uses don't mock all required properties
     which?: { [key: string]: string },
+    getVariable?:{ [key: string]: string},
 }
 
 export type MockedCommand = keyof TaskLibAnswers;

--- a/node/mock-task.ts
+++ b/node/mock-task.ts
@@ -291,6 +291,10 @@ export function find(findPath: string): string[] {
     return mock.getResponse('find', findPath, module.exports.debug);
 }
 
+export function getVariable(key: string): string {
+    return mock.getResponse('getVariable', key, module.exports.debug);
+}
+
 export function rmRF(path: string): void {
     module.exports.debug('rmRF ' + path);
     var response = mock.getResponse('rmRF', path, module.exports.debug);

--- a/node/test/mocktests.ts
+++ b/node/test/mocktests.ts
@@ -330,31 +330,17 @@ describe('Mock Tests', function () {
 
     it('gets task variables from a MockTestRuuner execution Mauta', function (done) {
 
-        // process.env['SECRET_PASSWORD'] = '123'
-        // process.env['VSTS_TASKVARIABLE_USERNAME'] = 'user_sample'
-
         var a: ma.TaskLibAnswers = <ma.TaskLibAnswers><unknown>{
             "getVariable": {
-                "SECRET_PASSWORD": "123"
-            }
-        };
-
-        var b: ma.TaskLibAnswers = <ma.TaskLibAnswers><unknown>{
-            "getVariable": {
+                "SECRET_PASSWORD": "123",
                 "VSTS_TASKVARIABLE_USERNAME": "user_sample"
             }
         };
 
-        // mt.setAnswers(a);
-        mt.setAnswers(b);
+        mt.setAnswers(a);
 
-        // const varval = mt.getVariable('SECRET_PASSWORD')
-        // console.log("varval ", varval)
-        // assert.equal(varval, '123');
-
-        const varval2 = mt.getVariable('VSTS_TASKVARIABLE_USERNAME')
-        console.log("varval2 ",varval2)
-        assert.equal(varval2, 'user_sample');
+        assert.equal(mt.getVariable('SECRET_PASSWORD'), '123');
+        assert.equal(mt.getVariable('VSTS_TASKVARIABLE_USERNAME'), 'user_sample');
         done();
     })
 

--- a/node/test/mocktests.ts
+++ b/node/test/mocktests.ts
@@ -327,4 +327,50 @@ describe('Mock Tests', function () {
         assert(semver.satisfies(version, '14.x'), 'Downloaded node version should be Node 14 instead of ' + version);
         done();
     })
+
+    it('gets task variables from a MockTestRuuner execution Mauta', function (done) {
+
+        // process.env['SECRET_PASSWORD'] = '123'
+        // process.env['VSTS_TASKVARIABLE_USERNAME'] = 'user_sample'
+
+        var a: ma.TaskLibAnswers = <ma.TaskLibAnswers><unknown>{
+            "getVariable": {
+                "SECRET_PASSWORD": "123"
+            }
+        };
+
+        var b: ma.TaskLibAnswers = <ma.TaskLibAnswers><unknown>{
+            "getVariable": {
+                "VSTS_TASKVARIABLE_USERNAME": "user_sample"
+            }
+        };
+
+        // mt.setAnswers(a);
+        mt.setAnswers(b);
+
+        // const varval = mt.getVariable('SECRET_PASSWORD')
+        // console.log("varval ", varval)
+        // assert.equal(varval, '123');
+
+        const varval2 = mt.getVariable('VSTS_TASKVARIABLE_USERNAME')
+        console.log("varval2 ",varval2)
+        assert.equal(varval2, 'user_sample');
+        done();
+    })
+
+    it('gets task variables from a MockTestRuuner execution', function (done) {
+        this.timeout(15000);
+
+        var task_path = path.join(__dirname , 'fakeTasks', 'fake_task.js')
+
+        const runner = new mtm.MockTestRunner(task_path)
+
+        process.env['SECRET_PASSWORD'] = '123'
+        process.env['VSTS_TASKVARIABLE_USERNAME'] = 'user_sample'
+
+        runner.run()
+
+        assert.strictEqual(runner.succeeded, true, 'it should succeed getting the variables');
+        done();
+    })
 });

--- a/node/test/mocktests.ts
+++ b/node/test/mocktests.ts
@@ -328,7 +328,7 @@ describe('Mock Tests', function () {
         done();
     })
 
-    it('gets task variables from a MockTestRuuner execution Mauta', function (done) {
+    it('get mock values of environment variables using getVariable', function (done) {
 
         var a: ma.TaskLibAnswers = <ma.TaskLibAnswers><unknown>{
             "getVariable": {
@@ -339,8 +339,11 @@ describe('Mock Tests', function () {
 
         mt.setAnswers(a);
 
-        assert.equal(mt.getVariable('SECRET_PASSWORD'), '123');
-        assert.equal(mt.getVariable('VSTS_TASKVARIABLE_USERNAME'), 'user_sample');
+        const varValFirst = mt.getVariable('SECRET_PASSWORD')
+        const varValSecond = mt.getVariable('VSTS_TASKVARIABLE_USERNAME')
+
+        assert.equal(varValFirst, '123');
+        assert.equal(varValSecond, 'user_sample');
         done();
     })
 


### PR DESCRIPTION
wrote a mock test for values of environment variables using getVariable

for issue [#716 How can I mock a pipeline variable in my tests?](https://github.com/microsoft/azure-pipelines-task-lib/issues/716)

and for issue [#717 Fix unavailable public variables when creating tests](https://github.com/microsoft/azure-pipelines-task-lib/issues/717)