### PR TITLE
Fix getting tool output in the CI test

### DIFF
--- a/node/test/toolrunnertests.ts
+++ b/node/test/toolrunnertests.ts
@@ -2209,7 +2209,7 @@ describe('Toolrunner Tests', function () {
                 let exeRunner = tl.tool(exePath);
                 exeRunner.line('-TEST1="space test" "-TEST2=%WIN_TEST%" \'-TEST3=value\'');
                 exeRunner.on('stdout', (data) => {
-                    output = data.toString();
+                    output += data.toString();
                 });
                 exeRunner.exec(_testExecOptions).then(function (code) {
                     assert.equal(code, 0, 'return code of cmd should be 0');


### PR DESCRIPTION
**Description:** In the test C# code we use Console.WriteLine() function in the loop. This function can trigger one common "stdout" event with whole output or "stdout" events on each call. 

**Description of fix:** Concat outputs from test tool on every "stdout" event to get whole output.
