### PR TITLE
Bump up task lib patch version to 3.1.7

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",


### PR DESCRIPTION
**Description**: 
We need to bump up the task lib version to publish recent changes

**Changes**:
- Updated package patch version in `node/package.json` and `package-lock.json` files