### PR TITLE
Fix documentation, comment and condition for getEndpointAuthorization function

### DIFF
--- a/node/docs/azure-pipelines-task-lib.md
+++ b/node/docs/azure-pipelines-task-lib.md
@@ -616,7 +616,7 @@ scheme | string | auth scheme such as OAuth or username/password etc...
  
 ### task.getEndpointAuthorization <a href="#index">(^)</a>
 Gets the authorization details for a service endpoint
-If the authorization was not set and is not optional, it will specify task result as failed in case of exception.
+If the authorization was not set and is not optional, it will set the task result to Failed.
 
 @returns   string
 ```javascript

--- a/node/docs/azure-pipelines-task-lib.md
+++ b/node/docs/azure-pipelines-task-lib.md
@@ -616,7 +616,7 @@ scheme | string | auth scheme such as OAuth or username/password etc...
  
 ### task.getEndpointAuthorization <a href="#index">(^)</a>
 Gets the authorization details for a service endpoint
-If the authorization was not set and is not optional, it will write logs and return undefined.
+If the authorization was not set and is not optional, it will specify task result as failed in case of exception.
 
 @returns   string
 ```javascript

--- a/node/docs/azure-pipelines-task-lib.md
+++ b/node/docs/azure-pipelines-task-lib.md
@@ -616,7 +616,7 @@ scheme | string | auth scheme such as OAuth or username/password etc...
  
 ### task.getEndpointAuthorization <a href="#index">(^)</a>
 Gets the authorization details for a service endpoint
-If the authorization was not set and is not optional, it will throw.
+If the authorization was not set and is not optional, it will write logs and return undefined.
 
 @returns   string
 ```javascript

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",

--- a/node/task.ts
+++ b/node/task.ts
@@ -407,7 +407,7 @@ export interface EndpointAuthorization {
 
 /**
  * Gets the authorization details for a service endpoint
- * If the authorization was not set and is not optional, it will write logs and return undefined.
+ * If the authorization was not set and is not optional, it will specify task result as failed in case of exception.
  *
  * @param     id        name of the service endpoint
  * @param     optional  whether the url is optional
@@ -420,7 +420,7 @@ export function getEndpointAuthorization(id: string, optional: boolean): Endpoin
         setResult(TaskResult.Failed, loc('LIB_EndpointAuthNotExist', id));
     }
 
-    debug(id + ' exists ' + (aval !== undefined));
+    debug(id + ' exists ' + (!!aval));
 
     var auth: EndpointAuthorization | undefined;
     try {

--- a/node/task.ts
+++ b/node/task.ts
@@ -407,7 +407,7 @@ export interface EndpointAuthorization {
 
 /**
  * Gets the authorization details for a service endpoint
- * If the authorization was not set and is not optional, it will specify task result as failed in case of exception.
+ * If the authorization was not set and is not optional, it will set the task result to Failed.
  *
  * @param     id        name of the service endpoint
  * @param     optional  whether the url is optional

--- a/node/task.ts
+++ b/node/task.ts
@@ -407,7 +407,7 @@ export interface EndpointAuthorization {
 
 /**
  * Gets the authorization details for a service endpoint
- * If the authorization was not set and is not optional, it will throw.
+ * If the authorization was not set and is not optional, it will write logs and return undefined.
  *
  * @param     id        name of the service endpoint
  * @param     optional  whether the url is optional
@@ -420,7 +420,7 @@ export function getEndpointAuthorization(id: string, optional: boolean): Endpoin
         setResult(TaskResult.Failed, loc('LIB_EndpointAuthNotExist', id));
     }
 
-    debug(id + ' exists ' + (aval !== null));
+    debug(id + ' exists ' + (aval !== undefined));
 
     var auth: EndpointAuthorization | undefined;
     try {


### PR DESCRIPTION
Fix documentation, comment and condition for getEndpointAuthorization function

The condition was changed because **aval** has type string | undefined, so its value will probably never be null and it will be better to use !!aval for more strong verification, it will allow us to check the empty string also.

related issue #775 
