### PR TITLE
Add platform FreeBSD

### DIFF
--- a/node/task.ts
+++ b/node/task.ts
@@ -56,7 +56,8 @@ export const IssueSource = im.IssueSource;
 export enum Platform {
     Windows,
     MacOS,
-    Linux
+    Linux,
+    FreeBSD
 }
 
 export enum AgentHostedMode {
@@ -732,6 +733,7 @@ export function getPlatform(): Platform {
         case 'win32': return Platform.Windows;
         case 'darwin': return Platform.MacOS;
         case 'linux': return Platform.Linux;
+        case 'freebsd': return Platform.FreeBSD;
         default: throw Error(loc('LIB_PlatformNotSupported', process.platform));
     }
 }


### PR DESCRIPTION
Since [PR 3266](https://github.com/microsoft/azure-pipelines-agent/pull/3266) makes it possible to run the Azure Pipelines Agent on FreeBSD, it would also make sense that the Azure Pipelines Task SDK supports this platform as well. Currently, for example, the [Extract Files task](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/extract-files) fails on FreeBSD with the following error:

```
##[error]Unhandled: Platform not supported: freebsd
```

This is because [extractfilestask.ts](https://github.com/microsoft/azure-pipelines-tasks/blob/master/Tasks/ExtractFilesV1/extractfilestask.ts#L17) calls `getPlatform` to determine whether running on Windows. If the current platform is neither Windows, nor MacOS, nor Linux, `getPlatform` throws the above exception. However, this can be easily fixed with this PR by adding `FreeBSD` to the `Platform` enum and returning it in the `getPlatform` function instead of throwing an exception.