### PR TITLE
Add OneLocBuild removal to the localization pipeline

### DIFF
--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -71,8 +71,14 @@ stages:
 
         git checkout -b $updateBranch
 
-        Remove-Item -Recurse -Force Localize, OneLocBuild -ErrorAction Ignore
-
+        if (Test-Path -Path Localize) { 
+          Remove-Item -Recurse -Force Localize 
+        }
+        
+        if (Test-Path -Path OneLocBuild) { 
+          Remove-Item -Recurse -Force OneLocBuild 
+        }
+        
         git add -A
         git commit -m "Removing Localize and OneLocBuild folder"
         git push origin $updateBranch

--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -71,10 +71,10 @@ stages:
 
         git checkout -b $updateBranch
 
-        Remove-Item -Recurse -Force Localize
+        Remove-Item -Recurse -Force Localize, OneLocBuild -ErrorAction Ignore
 
         git add -A
-        git commit -m "Removing Localize folder"
+        git commit -m "Removing Localize and OneLocBuild folder"
         git push origin $updateBranch
       displayName: Create and push localization update branch
       condition: and(succeeded(), or(and(eq(variables['SHOULDCREATEPR'], 'True'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))


### PR DESCRIPTION
Related [issue](https://github.com/microsoft/build-task-team/issues/1844)
Added removal of the OneLocBuild to the command that removes Localization folder, as well as a parameter to ignore error if the folder doesn't exist, that allows deleting any of the folders that exist while skipping error if one of them doesn't 