### PR TITLE
Adds parameter to ToolRunner.killChildProcess to specify which signal to send #858

### DIFF
--- a/node/toolrunner.ts
+++ b/node/toolrunner.ts
@@ -1028,12 +1028,14 @@ export class ToolRunner extends events.EventEmitter {
     }
 
     /**
-     * Used to close child process by sending SIGNINT signal.
-     * It allows executed script to have some additional logic on SIGINT, before exiting.
+     * Sends a signal to kill the child process. If no argument is given, the SIGTERM signal will be sent.
+     * This allows the executed script to react to kill signals before being forcibly terminated.
+     * 
+     * @param signal    The signal to send to the child process (default is SIGTERM)
      */
-    public killChildProcess(): void {
+    public killChildProcess(signal?: string): void {
         if (this.childProcess) {
-            this.childProcess.kill();
+            this.childProcess.kill(signal);
         }
     }
 }


### PR DESCRIPTION
Also corrects and clarifies TSDoc comment.

This PR fixes #858 (by correcting method TSDoc wording). In addition, this PR will in allow fixing https://github.com/microsoft/azure-pipelines-tasks/issues/16731 in downstream `BashV3` task by making use of the added parameter to send the correct kill signal.

Note that this is a **non-breaking change**; existing code that calls `ToolRunner.killChildProcess()` without an argument will continue to see the exact same behavior.