### PR TITLE
Bump version

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "4.0.0-preview",
+  "version": "4.0.1-preview",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "azure-pipelines-task-lib",
-      "version": "4.0.0-preview",
+      "version": "4.0.1-preview",
       "license": "MIT",
       "dependencies": {
         "minimatch": "3.0.5",

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "4.0.0-preview",
+  "version": "4.0.1-preview",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",


### PR DESCRIPTION
## Description
This PR increases the version of task-lib to 4.0.1-preview. The previous [PR](https://github.com/microsoft/azure-pipelines-task-lib/pull/852) did not update the version so it will be done here

## Testing
No testing need