### PR TITLE
chore: bump uuid lib

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -15,7 +15,7 @@
         "semver": "^5.1.0",
         "shelljs": "^0.8.5",
         "sync-request": "6.1.0",
-        "uuid": "^3.0.1"
+        "uuid": "^8.3.2"
       },
       "devDependencies": {
         "@types/minimatch": "3.0.3",
@@ -1271,12 +1271,11 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "node_modules/uuid": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/which": {
@@ -2327,9 +2326,9 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "which": {
       "version": "2.0.2",

--- a/node/package.json
+++ b/node/package.json
@@ -33,7 +33,7 @@
     "semver": "^5.1.0",
     "shelljs": "^0.8.5",
     "sync-request": "6.1.0",
-    "uuid": "^3.0.1"
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@types/minimatch": "3.0.3",

--- a/node/vault.ts
+++ b/node/vault.ts
@@ -4,7 +4,7 @@ import fs = require('fs');
 import path = require('path');
 import crypto = require('crypto');
 
-var uuidV4 = require('uuid/v4');
+var { v4: uuidV4 } = require('uuid');
 var algorithm = "aes-256-ctr";
 var encryptEncoding: 'hex' = 'hex';
 var unencryptedEncoding: 'utf8' = 'utf8';


### PR DESCRIPTION
This bumps the UUID package to v8. Similar to this PR, https://github.com/microsoft/azure-pipelines-task-lib/pull/850, however this bumps to v8 rather than v7, and updates the code to address breaking changes. The other difference is my PR is targeting the latest release branch (4.x), rather than master which appears to still be on 3.x.

UUIDv8 is the final version to support NodeJS 10, which as far as I can tell is currently a required target for this project. If this isn't the case I'm happy to bump this to v9.

My motivation for this change is that this change, specifically the code change, make this code compatible with v9 at runtime. Due to an issue with versions of uuid prior to 9, jest tests cannot run correctly with the `jsdom` environment when uuid <=8 is in use. This can be resolved by the consuming app with yarn/npm resolutions to force v9 to be used, but as the code in this library is currently incompatible with v8 & v9 prior to this change, the resolution causes this to fail at runtime.