### PR TITLE
Enable task authors to determine whether the task is running on a hosted agent, or not.

### DIFF
--- a/node/docs/azure-pipelines-task-lib.json
+++ b/node/docs/azure-pipelines-task-lib.json
@@ -683,14 +683,14 @@
         "getAgentMode": {
           "name": "getAgentMode",
           "members": {},
-          "documentation": "Gets a agent hosted mode.\nRequires a 2.212.0 agent or higher for full functionality. With lower version returns AgentHostedMode.Unknown value. \n\n@returns AgentHostedMode",
+          "documentation": "Gets a agent hosted mode: Unknown, SelfHosted or MsHosted.\nRequires a 2.212.0 agent or higher for full functionality. With lower version returns AgentHostedMode.Unknown value. \n\n@returns AgentHostedMode",
           "kind": "function",
           "signatures": [
             {
               "parameters": [],
               "members": {},
               "return": "AgentHostedMode",
-              "documentation": "Gets a agent hosted mode.\nRequires a 2.212.0 agent or higher for full functionality. With lower version returns AgentHostedMode.Unknown value. \n\n@returns AgentHostedMode"
+              "documentation": "Gets a agent hosted mode: Unknown, SelfHosted or MsHosted.\nRequires a 2.212.0 agent or higher for full functionality. With lower version returns AgentHostedMode.Unknown value. \n\n@returns AgentHostedMode"
             }
           ]
         },

--- a/node/docs/azure-pipelines-task-lib.json
+++ b/node/docs/azure-pipelines-task-lib.json
@@ -680,6 +680,20 @@
             }
           ]
         },
+        "getAgentMode": {
+          "name": "getAgentMode",
+          "members": {},
+          "documentation": "Gets a agent hosted mode.\nRequires a 2.212.0 agent or higher for full functionality. With lower version returns AgentHostedMode.Unknown value. \n\n@returns AgentHostedMode",
+          "kind": "function",
+          "signatures": [
+            {
+              "parameters": [],
+              "members": {},
+              "return": "AgentHostedMode",
+              "documentation": "Gets a agent hosted mode.\nRequires a 2.212.0 agent or higher for full functionality. With lower version returns AgentHostedMode.Unknown value. \n\n@returns AgentHostedMode"
+            }
+          ]
+        },
         "setVariable": {
           "name": "setVariable",
           "members": {},

--- a/node/docs/azure-pipelines-task-lib.md
+++ b/node/docs/azure-pipelines-task-lib.md
@@ -289,12 +289,13 @@ Limitations on an agent prior to 2.104.1:
 @returns VariableInfo[]
 ```javascript
 getVariables():VariableInfo[]
+```
 
 <br/>
 <div id="taskgetAgentMode">
 
 ### task.getAgentMode <a href="#index">(^)</a>
-Gets a agent hosted mode.
+Gets a agent hosted mode: Unknown, SelfHosted or MsHosted.
 Requires a 2.212.0 agent or higher for full functionality. With lower version returns AgentHostedMode.Unknown value.
 
 @returns AgentHostedMode

--- a/node/docs/azure-pipelines-task-lib.md
+++ b/node/docs/azure-pipelines-task-lib.md
@@ -35,6 +35,7 @@ import tl = require('azure-pipelines-task-lib/task')
 <a href="#tasksetVariable">setVariable</a> <br/>
 <a href="#taskgetTaskVariable">getTaskVariable</a> <br/>
 <a href="#tasksetTaskVariable">setTaskVariable</a> <br/>
+<a href="#taskgetAgentMode">getAgentMode</a> <br/>
 
 ### Execution <a href="#Execution">(v)</a>
 
@@ -288,6 +289,17 @@ Limitations on an agent prior to 2.104.1:
 @returns VariableInfo[]
 ```javascript
 getVariables():VariableInfo[]
+
+<br/>
+<div id="taskgetAgentMode">
+
+### task.getAgentMode <a href="#index">(^)</a>
+Gets a agent hosted mode.
+Requires a 2.212.0 agent or higher for full functionality. With lower version returns AgentHostedMode.Unknown value.
+
+@returns AgentHostedMode
+```javascript
+getAgentMode():AgentHostedMode
 ```
 
 <br/>

--- a/node/docs/docs.json
+++ b/node/docs/docs.json
@@ -23,7 +23,8 @@
                 "task.getVariables",
                 "task.setVariable",
                 "task.getTaskVariable",
-                "task.setTaskVariable"
+                "task.setTaskVariable",
+                "task.getAgentMode"
             ]
         },
         "Execution": {

--- a/node/mock-answer.ts
+++ b/node/mock-answer.ts
@@ -14,6 +14,7 @@ export interface TaskLibAnswers {
     find?: { [key: string]: string[] },
     findMatch?: { [key: string]: string[] },
     getPlatform?: { [key: string]: task.Platform },
+    getAgentMode?: { [key: string]: task.AgentHostedMode },
     legacyFindFiles?: { [key: string]: string[] },
     ls?: { [key: string]: string },
     osType?: { [key: string]: string },

--- a/node/mock-task.ts
+++ b/node/mock-task.ts
@@ -222,6 +222,10 @@ export function getPlatform(): task.Platform {
     return mock.getResponse('getPlatform', 'getPlatform', module.exports.debug);
 }
 
+export function getAgentMode(): task.AgentHostedMode {
+    return mock.getResponse('getAgentMode', 'getAgentMode', module.exports.debug);
+}
+
 export function cwd(): string {
     return mock.getResponse('cwd', 'cwd', module.exports.debug);
 }

--- a/node/task.ts
+++ b/node/task.ts
@@ -51,6 +51,12 @@ export enum Platform {
     Linux
 }
 
+export enum AgentHostedMode {
+    Unknown,
+    SelfHosted,
+    MsHosted
+}
+
 //-----------------------------------------------------
 // General Helpers
 //-----------------------------------------------------
@@ -657,6 +663,22 @@ export function getPlatform(): Platform {
         case 'linux': return Platform.Linux;
         default: throw Error(loc('LIB_PlatformNotSupported', process.platform));
     }
+}
+
+/**
+ * Return hosted type of Agent
+ * @returns {AgentHostedMode}
+ */
+export function getAgentMode(): AgentHostedMode {
+    let agentCloudId = getVariable('Agent.CloudId');
+
+    if (agentCloudId === undefined)
+        return AgentHostedMode.Unknown;
+    
+    if (agentCloudId)
+        return AgentHostedMode.MsHosted;
+
+    return AgentHostedMode.SelfHosted;
 }
 
 /**


### PR DESCRIPTION
**Description**:
Added export function getAgentMode for getting the agent hosted type.
It works throw Agent.CloudId property.

**Changelog**:
Function getAgentMode added to task
Function getAgentMode added to mock

**Documentation changes required**: Yes

Added unit tests: No

**Attached related issue**: Link to PR in the issue