### PR TITLE
fix ToolRunner - _getSpawnSyncOptions

### DIFF
--- a/node/toolrunner.ts
+++ b/node/toolrunner.ts
@@ -594,6 +594,7 @@ export class ToolRunner extends events.EventEmitter {
 
     private _getSpawnSyncOptions(options: IExecSyncOptions): child.SpawnSyncOptions {
         let result = <child.SpawnSyncOptions>{};
+        result.maxBuffer = 1024 * 1024 * 1024;
         result.cwd = options.cwd;
         result.env = options.env;
         result.shell = options.shell;


### PR DESCRIPTION
The max buffer was limited in the higher node version. We have to increase it manually.

[Related issue](https://github.com/microsoft/build-task-team/issues/3588)