### PR TITLE
Updated PSLIB_InvalidPattern0 to be more readable

### DIFF
--- a/powershell/VstsTaskSdk/LegacyFindFunctions.ps1
+++ b/powershell/VstsTaskSdk/LegacyFindFunctions.ps1
@@ -132,7 +132,7 @@ function Find-Files {
         }
 
         # Validate pattern does not end with a \.
-        if ($pattern[$pattern.Length - 1] -eq [System.IO.Path]::DirectorySeparatorChar) {
+        if ($pattern.EndsWith([System.IO.Path]::DirectorySeparatorChar)) {
             throw (Get-LocString -Key PSLIB_InvalidPattern0 -ArgumentList $pattern)
         }
 

--- a/powershell/VstsTaskSdk/Strings/resources.resjson/en-US/resources.resjson
+++ b/powershell/VstsTaskSdk/Strings/resources.resjson/en-US/resources.resjson
@@ -6,7 +6,7 @@
   "loc.messages.PSLIB_EnumeratingSubdirectoriesFailedForPath0": "Enumerating subdirectories failed for path: '{0}'",
   "loc.messages.PSLIB_FileNotFound0": "File not found: '{0}'",
   "loc.messages.PSLIB_Input0": "'{0}' input",
-  "loc.messages.PSLIB_InvalidPattern0": "Invalid pattern: '{0}'",
+  "loc.messages.PSLIB_InvalidPattern0": "Path cannot end with a directory separator character: '{0}'",
   "loc.messages.PSLIB_LeafPathNotFound0": "Leaf path not found: '{0}'",
   "loc.messages.PSLIB_PathLengthNotReturnedFor0": "Path normalization/expansion failed. The path length was not returned by the Kernel32 subsystem for: '{0}'",
   "loc.messages.PSLIB_PathNotFound0": "Path not found: '{0}'",


### PR DESCRIPTION
The only place this localized string used is here:

https://github.com/microsoft/azure-pipelines-task-lib/blob/5adadaedd70e68a4130f339e0faf8b8a9a72d273/powershell/VstsTaskSdk/LegacyFindFunctions.ps1#L134-L137

In real world, the error looks like this 

```
##[error]Invalid pattern: 'C:\__w\1\s\src\Application\pkg\Release\'
```

Which is too vague to make it possible to troubleshoot without finding and looking into the source code. I ran into this error here: https://github.com/microsoft/azure-pipelines-tasks/issues/17106.

This PR includes:

1. improving the error message. 
2. using `EndsWith()` instead of `$str[$str,Legth -1]` for readability


However, what doesn't include:

1. I didn't rename the placeholder
2. nor updated the localizations

Please let me know if I should do the former and what's the process for the latter (I can update the ru-ru string though).