### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 10947: Build ID 18673037

### DIFF
--- a/powershell/VstsTaskSdk/Strings/resources.resjson/de-de/resources.resjson
+++ b/powershell/VstsTaskSdk/Strings/resources.resjson/de-de/resources.resjson
@@ -1,0 +1,18 @@
+{
+  "loc.messages.PSLIB_AgentVersion0Required": "Agentversion {0} oder höher ist erforderlich.",
+  "loc.messages.PSLIB_ContainerPathNotFound0": "Der Containerpfad wurde nicht gefunden: \"{0}\".",
+  "loc.messages.PSLIB_EndpointAuth0": "\"{0}\"-Dienstendpunkt-Anmeldeinformationen",
+  "loc.messages.PSLIB_EndpointUrl0": "\"{0}\"-Dienstendpunkt-URL",
+  "loc.messages.PSLIB_EnumeratingSubdirectoriesFailedForPath0": "Fehler beim Aufzählen von Unterverzeichnissen für den folgenden Pfad: \"{0}\"",
+  "loc.messages.PSLIB_FileNotFound0": "Die Datei wurde nicht gefunden: \"{0}\".",
+  "loc.messages.PSLIB_Input0": "\"{0}\"-Eingabe",
+  "loc.messages.PSLIB_InvalidPattern0": "Path cannot end with a directory separator character: '{0}'",
+  "loc.messages.PSLIB_LeafPathNotFound0": "Der Blattpfad wurde nicht gefunden: \"{0}\".",
+  "loc.messages.PSLIB_PathLengthNotReturnedFor0": "Fehler bei der Normalisierung bzw. Erweiterung des Pfads. Die Pfadlänge wurde vom Kernel32-Subsystem nicht zurückgegeben für: \"{0}\"",
+  "loc.messages.PSLIB_PathNotFound0": "Der Pfad wurde nicht gefunden: \"{0}\".",
+  "loc.messages.PSLIB_Process0ExitedWithCode1": "Der Prozess \"{0}\" wurde mit dem Code \"{1}\" beendet.",
+  "loc.messages.PSLIB_Required0": "Erforderlich: {0}",
+  "loc.messages.PSLIB_StringFormatFailed": "Fehler beim Zeichenfolgenformat.",
+  "loc.messages.PSLIB_StringResourceKeyNotFound0": "Der Zeichenfolgen-Ressourcenschlüssel wurde nicht gefunden: \"{0}\".",
+  "loc.messages.PSLIB_TaskVariable0": "\"{0}\"-Taskvariable"
+}

--- a/powershell/VstsTaskSdk/Strings/resources.resjson/es-es/resources.resjson
+++ b/powershell/VstsTaskSdk/Strings/resources.resjson/es-es/resources.resjson
@@ -1,0 +1,18 @@
+{
+  "loc.messages.PSLIB_AgentVersion0Required": "Se require la versión {0} o posterior del agente.",
+  "loc.messages.PSLIB_ContainerPathNotFound0": "No se encuentra la ruta de acceso del contenedor: '{0}'",
+  "loc.messages.PSLIB_EndpointAuth0": "Credenciales del punto de conexión de servicio '{0}'",
+  "loc.messages.PSLIB_EndpointUrl0": "URL del punto de conexión de servicio '{0}'",
+  "loc.messages.PSLIB_EnumeratingSubdirectoriesFailedForPath0": "No se pudieron enumerar los subdirectorios de la ruta de acceso: '{0}'",
+  "loc.messages.PSLIB_FileNotFound0": "Archivo no encontrado: '{0}'",
+  "loc.messages.PSLIB_Input0": "Entrada '{0}'",
+  "loc.messages.PSLIB_InvalidPattern0": "Path cannot end with a directory separator character: '{0}'",
+  "loc.messages.PSLIB_LeafPathNotFound0": "No se encuentra la ruta de acceso de la hoja: '{0}'",
+  "loc.messages.PSLIB_PathLengthNotReturnedFor0": "No se pudo normalizar o expandir la ruta de acceso. El subsistema Kernel32 no devolvió la longitud de la ruta de acceso para: '{0}'",
+  "loc.messages.PSLIB_PathNotFound0": "No se encuentra la ruta de acceso: '{0}'",
+  "loc.messages.PSLIB_Process0ExitedWithCode1": "El proceso '{0}' finalizó con el código '{1}'.",
+  "loc.messages.PSLIB_Required0": "Se requiere: {0}",
+  "loc.messages.PSLIB_StringFormatFailed": "Error de formato de cadena.",
+  "loc.messages.PSLIB_StringResourceKeyNotFound0": "No se encuentra la clave de recurso de la cadena: '{0}'",
+  "loc.messages.PSLIB_TaskVariable0": "Variable de tarea '{0}'"
+}

--- a/powershell/VstsTaskSdk/Strings/resources.resjson/fr-fr/resources.resjson
+++ b/powershell/VstsTaskSdk/Strings/resources.resjson/fr-fr/resources.resjson
@@ -1,0 +1,18 @@
+{
+  "loc.messages.PSLIB_AgentVersion0Required": "L'agent version {0} (ou une version ultérieure) est obligatoire.",
+  "loc.messages.PSLIB_ContainerPathNotFound0": "Le chemin du conteneur est introuvable : '{0}'",
+  "loc.messages.PSLIB_EndpointAuth0": "Informations d'identification du point de terminaison de service '{0}'",
+  "loc.messages.PSLIB_EndpointUrl0": "URL du point de terminaison de service '{0}'",
+  "loc.messages.PSLIB_EnumeratingSubdirectoriesFailedForPath0": "Échec de l'énumération des sous-répertoires pour le chemin : '{0}'",
+  "loc.messages.PSLIB_FileNotFound0": "Fichier introuvable : {0}.",
+  "loc.messages.PSLIB_Input0": "Entrée '{0}'",
+  "loc.messages.PSLIB_InvalidPattern0": "Path cannot end with a directory separator character: '{0}'",
+  "loc.messages.PSLIB_LeafPathNotFound0": "Le chemin feuille est introuvable : '{0}'",
+  "loc.messages.PSLIB_PathLengthNotReturnedFor0": "Échec de la normalisation/l'expansion du chemin. La longueur du chemin n'a pas été retournée par le sous-système Kernel32 pour : '{0}'",
+  "loc.messages.PSLIB_PathNotFound0": "Chemin introuvable : '{0}'",
+  "loc.messages.PSLIB_Process0ExitedWithCode1": "Le processus '{0}' s'est arrêté avec le code '{1}'.",
+  "loc.messages.PSLIB_Required0": "Obligatoire : {0}",
+  "loc.messages.PSLIB_StringFormatFailed": "Échec du format de la chaîne.",
+  "loc.messages.PSLIB_StringResourceKeyNotFound0": "Clé de la ressource de type chaîne introuvable : '{0}'",
+  "loc.messages.PSLIB_TaskVariable0": "Variable de tâche '{0}'"
+}

--- a/powershell/VstsTaskSdk/Strings/resources.resjson/it-IT/resources.resjson
+++ b/powershell/VstsTaskSdk/Strings/resources.resjson/it-IT/resources.resjson
@@ -6,7 +6,7 @@
   "loc.messages.PSLIB_EnumeratingSubdirectoriesFailedForPath0": "L'enumerazione delle sottodirectory per il percorso '{0}' non è riuscita",
   "loc.messages.PSLIB_FileNotFound0": "File non trovato: '{0}'",
   "loc.messages.PSLIB_Input0": "Input di '{0}'",
-  "loc.messages.PSLIB_InvalidPattern0": "Criterio non valido: '{0}'",
+  "loc.messages.PSLIB_InvalidPattern0": "Path cannot end with a directory separator character: '{0}'",
   "loc.messages.PSLIB_LeafPathNotFound0": "Percorso foglia non trovato: '{0}'",
   "loc.messages.PSLIB_PathLengthNotReturnedFor0": "La normalizzazione o l'espansione del percorso non è riuscita. Il sottosistema Kernel32 non ha restituito la lunghezza del percorso per '{0}'",
   "loc.messages.PSLIB_PathNotFound0": "Percorso non trovato: '{0}'",

--- a/powershell/VstsTaskSdk/Strings/resources.resjson/ja-jp/resources.resjson
+++ b/powershell/VstsTaskSdk/Strings/resources.resjson/ja-jp/resources.resjson
@@ -1,0 +1,18 @@
+{
+  "loc.messages.PSLIB_AgentVersion0Required": "バージョン {0} 以降のエージェントが必要です。",
+  "loc.messages.PSLIB_ContainerPathNotFound0": "コンテナーのパスが見つかりません: '{0}'",
+  "loc.messages.PSLIB_EndpointAuth0": "'{0}' サービス エンドポイントの資格情報",
+  "loc.messages.PSLIB_EndpointUrl0": "'{0}' サービス エンドポイントの URL",
+  "loc.messages.PSLIB_EnumeratingSubdirectoriesFailedForPath0": "パス '{0}' のサブディレクトリを列挙できませんでした",
+  "loc.messages.PSLIB_FileNotFound0": "ファイルが見つかりません: '{0}'",
+  "loc.messages.PSLIB_Input0": "'{0}' 入力",
+  "loc.messages.PSLIB_InvalidPattern0": "Path cannot end with a directory separator character: '{0}'",
+  "loc.messages.PSLIB_LeafPathNotFound0": "リーフ パスが見つかりません: '{0}'",
+  "loc.messages.PSLIB_PathLengthNotReturnedFor0": "パスの正規化/展開に失敗しました。Kernel32 サブシステムからパス '{0}' の長さが返されませんでした",
+  "loc.messages.PSLIB_PathNotFound0": "パスが見つかりません: '{0}'",
+  "loc.messages.PSLIB_Process0ExitedWithCode1": "プロセス '{0}' がコード '{1}' で終了しました。",
+  "loc.messages.PSLIB_Required0": "必要: {0}",
+  "loc.messages.PSLIB_StringFormatFailed": "文字列のフォーマットに失敗しました。",
+  "loc.messages.PSLIB_StringResourceKeyNotFound0": "文字列のリソース キーが見つかりません: '{0}'",
+  "loc.messages.PSLIB_TaskVariable0": "'{0}' タスク変数"
+}

--- a/powershell/VstsTaskSdk/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/powershell/VstsTaskSdk/Strings/resources.resjson/ko-KR/resources.resjson
@@ -6,7 +6,7 @@
   "loc.messages.PSLIB_EnumeratingSubdirectoriesFailedForPath0": "경로에 대해 하위 디렉터리를 열거하지 못함: '{0}'",
   "loc.messages.PSLIB_FileNotFound0": "{0} 파일을 찾을 수 없습니다.",
   "loc.messages.PSLIB_Input0": "'{0}' 입력",
-  "loc.messages.PSLIB_InvalidPattern0": "잘못된 패턴: '{0}'",
+  "loc.messages.PSLIB_InvalidPattern0": "Path cannot end with a directory separator character: '{0}'",
   "loc.messages.PSLIB_LeafPathNotFound0": "Leaf 경로를 찾을 수 없음: '{0}'",
   "loc.messages.PSLIB_PathLengthNotReturnedFor0": "경로 정규화/확장에 실패했습니다. 다음에 대해 Kernel32 subsystem에서 경로 길이를 반환하지 않음: '{0}'",
   "loc.messages.PSLIB_PathNotFound0": "경로를 찾을 수 없음: '{0}'",

--- a/powershell/VstsTaskSdk/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/powershell/VstsTaskSdk/Strings/resources.resjson/ru-RU/resources.resjson
@@ -6,7 +6,7 @@
   "loc.messages.PSLIB_EnumeratingSubdirectoriesFailedForPath0": "Сбой перечисления подкаталогов для пути: \"{0}\".",
   "loc.messages.PSLIB_FileNotFound0": "Файл не найден: \"{0}\"",
   "loc.messages.PSLIB_Input0": "Входные данные \"{0}\".",
-  "loc.messages.PSLIB_InvalidPattern0": "Недопустимый шаблон: \"{0}\".",
+  "loc.messages.PSLIB_InvalidPattern0": "Path cannot end with a directory separator character: '{0}'",
   "loc.messages.PSLIB_LeafPathNotFound0": "Путь к конечному объекту не найден: \"{0}\".",
   "loc.messages.PSLIB_PathLengthNotReturnedFor0": "Сбой нормализации и расширения пути. Длина пути не была возвращена подсистемой Kernel32 для: \"{0}\".",
   "loc.messages.PSLIB_PathNotFound0": "Путь не найден: \"{0}\".",

--- a/powershell/VstsTaskSdk/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/powershell/VstsTaskSdk/Strings/resources.resjson/zh-CN/resources.resjson
@@ -6,7 +6,7 @@
   "loc.messages.PSLIB_EnumeratingSubdirectoriesFailedForPath0": "枚举路径的子目录失败:“{0}”",
   "loc.messages.PSLIB_FileNotFound0": "找不到文件: {0}。",
   "loc.messages.PSLIB_Input0": "“{0}”输入",
-  "loc.messages.PSLIB_InvalidPattern0": "无效的模式:“{0}”",
+  "loc.messages.PSLIB_InvalidPattern0": "Path cannot end with a directory separator character: '{0}'",
   "loc.messages.PSLIB_LeafPathNotFound0": "找不到叶路径:“{0}”",
   "loc.messages.PSLIB_PathLengthNotReturnedFor0": "路径规范化/扩展失败。路径长度不是由“{0}”的 Kernel32 子系统返回的",
   "loc.messages.PSLIB_PathNotFound0": "找不到路径:“{0}”",

--- a/powershell/VstsTaskSdk/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/powershell/VstsTaskSdk/Strings/resources.resjson/zh-TW/resources.resjson
@@ -6,7 +6,7 @@
   "loc.messages.PSLIB_EnumeratingSubdirectoriesFailedForPath0": "為路徑列舉子目錄失敗: '{0}'",
   "loc.messages.PSLIB_FileNotFound0": "找不到檔案: '{0}'",
   "loc.messages.PSLIB_Input0": "'{0}' 輸入",
-  "loc.messages.PSLIB_InvalidPattern0": "模式無效: '{0}'",
+  "loc.messages.PSLIB_InvalidPattern0": "Path cannot end with a directory separator character: '{0}'",
   "loc.messages.PSLIB_LeafPathNotFound0": "找不到分葉路徑: '{0}'",
   "loc.messages.PSLIB_PathLengthNotReturnedFor0": "路徑正規化/展開失敗。Kernel32 子系統未傳回 '{0}' 的路徑長度",
   "loc.messages.PSLIB_PathNotFound0": "找不到路徑: '{0}'",


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/ceLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.