### PR TITLE
Added unhandledRejection event

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",

--- a/node/task.ts
+++ b/node/task.ts
@@ -108,6 +108,20 @@ process.on('uncaughtException', (err: Error) => {
     error(String(err.stack));
 });
 
+//
+// Catching unhandled rejections from promises and rethrowing them as exceptions
+// For example, a promise that is rejected but not handled by a .catch() handler in node 10 
+// doesn't cause an uncaughtException but causes in Node 16.
+// For types definitions(Error | Any) see https://nodejs.org/docs/latest-v16.x/api/process.html#event-unhandledrejection
+//
+process.on('unhandledRejection', (reason: Error | any) => {
+    if (reason instanceof Error) {
+        throw reason;
+    } else {
+        throw new Error(reason);
+    }
+});
+
 //-----------------------------------------------------
 // Loc Helpers
 //-----------------------------------------------------


### PR DESCRIPTION
The main problem is that when we reject Promises, Node10 and Node16 behaviour is different.

For Node 10, when a promise was rejected without a .catch block will be emitted only [unhandledRejection](https://nodejs.org/docs/latest-v10.x/api/process.html#process_event_unhandledrejection)

For Node 16, when a promise was rejected without a .catch block will be emitted [unhandledRejection](https://nodejs.org/docs/latest-v16.x/api/process.html#event-unhandledrejection) first (if exists), and [uncaughtException](https://nodejs.org/docs/latest-v16.x/api/process.html#event-uncaughtexception) at the end.

In azure-pipelines-task-lib we handle all [uncaughtExceptions](https://github.com/microsoft/azure-pipelines-task-lib/blob/master/node/task.ts#L106) and set TaskResult.Failed.

So when we use node16 runner, it emits uncaughtExceptions on Promise rejection and the task fails, and when we use node 10 it does not emit uncaughtExceptions so the task successfully finishes.​

The event "unhandledRejection" was added on process.on to emit uncaughtExceptions on node10