### PR TITLE
Update toolrunner.ts

### DIFF
--- a/node/toolrunner.ts
+++ b/node/toolrunner.ts
@@ -607,9 +607,11 @@ export class ToolRunner extends events.EventEmitter {
 
         this._debug('exec tool: ' + this.toolPath);
         this._debug('arguments:');
-        this.args.forEach((arg) => {
-            this._debug('   ' + arg);
-        });
+        if (!optionsNonNull.silent) {
+            this.args.forEach((arg) => {
+                this._debug('   ' + arg);
+            });
+        }
 
         let success = true;
         const optionsNonNull = this._cloneExecOptions(options);
@@ -890,9 +892,11 @@ export class ToolRunner extends events.EventEmitter {
 
         this._debug('exec tool: ' + this.toolPath);
         this._debug('arguments:');
-        this.args.forEach((arg) => {
-            this._debug('   ' + arg);
-        });
+        if (!optionsNonNull.silent) {
+            this.args.forEach((arg) => {
+                this._debug('   ' + arg);
+            });
+        }
 
         const optionsNonNull = this._cloneExecOptions(options);
         if (!optionsNonNull.silent) {
@@ -1001,9 +1005,11 @@ export class ToolRunner extends events.EventEmitter {
     public execSync(options?: IExecSyncOptions): IExecSyncResult {
         this._debug('exec tool: ' + this.toolPath);
         this._debug('arguments:');
-        this.args.forEach((arg) => {
-            this._debug('   ' + arg);
-        });
+        if (!options.silent) {
+            this.args.forEach((arg) => {
+                this._debug('   ' + arg);
+            });
+        }
 
         var success = true;
         options = this._cloneExecOptions(options as IExecOptions);


### PR DESCRIPTION
In case the command line arguments contain secrets or any other info that should not be printed out. We could use the same 'silent' flag to not add all the arguments to debug log.