### PR TITLE
Update images in the CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
 #################################################
   displayName: windows
   pool:
-    vmImage: windows-2019
+    vmImage: windows-2022
 
   steps:
     - template: azure-pipelines-steps-node.yml
@@ -28,9 +28,9 @@ jobs:
 #################################################
   displayName: Linux
   pool:
-    vmImage: ubuntu-18.04
+    vmImage: ubuntu-22.04
 
-  steps:    
+  steps:
   - template: azure-pipelines-steps-node.yml
     parameters:
       nodeVersion: $(nodeVersion)
@@ -57,7 +57,7 @@ jobs:
 #################################################
   displayName: macOS
   pool:
-    vmImage: macOS-10.15
+    vmImage: macOS-12
 
   steps:
     - template: azure-pipelines-steps-node.yml

--- a/node/test/dirtests.ts
+++ b/node/test/dirtests.ts
@@ -1381,32 +1381,19 @@ describe('Dir Operation Tests', function () {
         tl.mkdirP(testPath);
         assert(shell.test('-d', testPath), 'directory created');
 
-        // can't remove folder with locked file on windows
+        // starting from windows-2022,
+        // can remove folder with locked file on windows as well,
+        // using the command `rd /s /q <path>`
         var filePath = path.join(testPath, 'file.txt');
         fs.appendFileSync(filePath, 'some data');
         assert(shell.test('-e', filePath), 'file exists');
 
         var fd = fs.openSync(filePath, 'r');
 
-        var worked = false;
-        try {
-            tl.rmRF(testPath);
-            worked = true;
-        }
-        catch (err) { }
-
-        if (os.platform() === 'win32') {
-            assert(!worked, 'should not work on windows');
-            assert(shell.test('-e', testPath), 'directory still exists');
-        }
-        else {
-            assert(worked, 'should work on nix');
-            assert(!shell.test('-e', testPath), 'directory removed');
-        }
-
-        fs.closeSync(fd);
         tl.rmRF(testPath);
         assert(!shell.test('-e', testPath), 'directory removed');
+
+        fs.closeSync(fd);
 
         done();
     });

--- a/node/test/toolrunnertests.ts
+++ b/node/test/toolrunnertests.ts
@@ -190,7 +190,8 @@ describe('Toolrunner Tests', function () {
             ls.exec(_testExecOptions)
                 .then(function (code) {
                     var contents = stdStream.getContents();
-                    assert(contents.indexOf('exec tool: /bin/ls') >= 0, 'should exec ls');
+                    const usr = os.platform() === 'linux' ? '/usr' : '';
+                    assert(contents.indexOf(`exec tool: ${usr}/bin/ls`) >= 0, 'should exec ls');
                     assert.equal(code, 0, 'return code of ls should be 0');
                     done();
                 })


### PR DESCRIPTION
***Description:*** We have to update the Ubuntu image used in the CI since `18.04` will be removed on April 1st.
The path to the `ls` tool has been changed from `/bin/ls` to `/usr/bin/ls` for Ubuntu.
A test to remove a non-empty directory with a locked file inside has been updated as well since such a directory can be removed starting from `windows-2022`.