### PR TITLE
chore: apply community recommended `tsconfig` for Node 16

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -4,6 +4,12 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
+    },
     "@types/concat-stream": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.0.tgz",
@@ -869,6 +875,14 @@
         "object-inspect": "^1.9.0"
       }
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -878,14 +892,6 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "requires": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -975,9 +981,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
-      "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "util-deprecate": {

--- a/node/package.json
+++ b/node/package.json
@@ -36,6 +36,7 @@
     "uuid": "^3.0.1"
   },
   "devDependencies": {
+    "@tsconfig/node16": "1.0.4",
     "@types/minimatch": "3.0.3",
     "@types/mocha": "^9.1.1",
     "@types/mockery": "^1.4.29",
@@ -44,6 +45,6 @@
     "@types/semver": "^7.3.4",
     "@types/shelljs": "^0.8.8",
     "mocha": "^9.2.2",
-    "typescript": "^4.0.0"
+    "typescript": "^4.9.5"
   }
 }

--- a/node/task.ts
+++ b/node/task.ts
@@ -1,3 +1,4 @@
+import { URL } from 'url';
 import Q = require('q');
 import shell = require('shelljs');
 import childProcess = require('child_process');

--- a/node/tsconfig.json
+++ b/node/tsconfig.json
@@ -1,10 +1,15 @@
 {
+    "extends": "@tsconfig/node16/tsconfig.json",
     "compilerOptions": {
-        "target": "ES5",
-        "module": "commonjs",
+        "module": "CommonJS",
         "declaration": true,
-        "moduleResolution": "node",
-        "strictNullChecks": true
+
+        // TODO: Fix these strict errors
+        "noImplicitAny": false,
+        "noImplicitThis": false,
+        "strictBindCallApply": false,
+        "strictPropertyInitialization": false,
+        "useUnknownInCatchVariables": false
     },
     "files": [
         "index.ts",


### PR DESCRIPTION
Other changes required:

- Update TypeScript to recognize the `ES2021` target
  - Chose 4.9.5 as it is the newest version that requires the fewest changes
- Explicitly import `URL`
- Remove properties from `tsconfig.json` that are duplicated in `@tsconfig/node16`
- Disable some strictness checks:
  - [`noImplicitAny`][1]
  - [`noImplicitThis`][2]
  - [`strictBindCallApply`][3]
  - [`strictPropertyInitialization`][4]
  - [`useUnknownInCatchVariables`][5]

`@tsconfig/node16` is equivalent to:

```json
{
  "$schema": "https://json.schemastore.org/tsconfig",
  "display": "Node 16",

  "compilerOptions": {
    "lib": ["es2021"],
    "module": "Node16",
    "target": "es2021",

    "strict": true,
    "esModuleInterop": true,
    "skipLibCheck": true,
    "forceConsistentCasingInFileNames": true,
    "moduleResolution": "node"
  }
}
```

[1]: https://www.typescriptlang.org/tsconfig#noImplicitAny
[2]: https://www.typescriptlang.org/tsconfig#noImplicitThis
[3]: https://www.typescriptlang.org/tsconfig#strictBindCallApply
[4]: https://www.typescriptlang.org/tsconfig#strictPropertyInitialization
[5]: https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables