### PR TITLE
chore: Add enforcement of no-implicit-any

### DIFF
--- a/node/internal.ts
+++ b/node/internal.ts
@@ -53,11 +53,11 @@ export function _writeLine(str: string): void {
     _outStream.write(str + os.EOL);
 }
 
-export function _setStdStream(stdStream): void {
+export function _setStdStream(stdStream: NodeJS.WriteStream): void {
     _outStream = stdStream;
 }
 
-export function _setErrStream(errStream): void {
+export function _setErrStream(errStream: NodeJS.WriteStream): void {
     _errStream = errStream;
 }
 

--- a/node/mock-task.ts
+++ b/node/mock-task.ts
@@ -268,7 +268,7 @@ export function checkPath(p: string, name: string): void {
 // - inject system.debug info
 // - have option to switch internal impl (shelljs now)
 //-----------------------------------------------------
-export function mkdirP(p): void {
+export function mkdirP(p: string): void {
     module.exports.debug('creating path: ' + p);
 }
 

--- a/node/mock-test.ts
+++ b/node/mock-test.ts
@@ -23,7 +23,7 @@ export class MockTestRunner {
     public nodePath = '';
     public stdout = '';
     public stderr = '';
-    public cmdlines = {};
+    public cmdlines: {[key:string]: boolean} = {};
     public invokedToolCount = 0;
     public succeeded = false;
     public errorIssues: string[] = [];
@@ -175,10 +175,10 @@ export class MockTestRunner {
             return 16;
         }
         const taskJsonContents = fs.readFileSync(taskJsonPath, { encoding: 'utf-8' });
-        const taskJson: object = JSON.parse(taskJsonContents);
+        const taskJson: {[key:string]: string} = JSON.parse(taskJsonContents);
 
         let nodeVersionFound = false;
-        const execution: object = (
+        const execution = (
             taskJson['execution']
             || taskJson['prejobexecution']
             || taskJson['postjobexecution']

--- a/node/mock-toolrunner.ts
+++ b/node/mock-toolrunner.ts
@@ -30,7 +30,7 @@ export interface IExecSyncResult {
     error: Error;
 }
 
-export function debug(message) {
+export function debug(message: string) {
     // do nothing, overridden
 }
 
@@ -48,7 +48,7 @@ export class ToolRunner extends events.EventEmitter {
     private args: string[];
     private pipeOutputToTool: ToolRunner | undefined;
 
-    private _debug(message) {
+    private _debug(message: string) {
         debug(message);
         this.emit('debug', message);
     }

--- a/node/task.ts
+++ b/node/task.ts
@@ -94,7 +94,7 @@ export function setResult(result: TaskResult, message: string, done?: boolean): 
     }
 
     // task.complete
-    var properties = { 'result': TaskResult[result] };
+    var properties: {[key:string]: string} = { 'result': TaskResult[result] };
     if (done) {
         properties['done'] = 'true';
     }
@@ -1967,7 +1967,7 @@ export function getHttpProxyConfiguration(requestUrl?: string): ProxyConfigurati
 
         let bypass: boolean = false;
         if (requestUrl) {
-            proxyBypassHosts.forEach(bypassHost => {
+            proxyBypassHosts.forEach( (bypassHost: string) => {
                 if (new RegExp(bypassHost, 'i').test(requestUrl)) {
                     bypass = true;
                 }

--- a/node/taskcommand.ts
+++ b/node/taskcommand.ts
@@ -9,7 +9,7 @@
 let CMD_PREFIX = '##vso[';
 
 export class TaskCommand {
-    constructor(command, properties, message) {
+    constructor(command: string, properties: {[key: string]: string}, message: string) {
         if (!command) {
             command = 'missing.command';
         }
@@ -51,7 +51,7 @@ export class TaskCommand {
     }
 }
 
-export function commandFromString(commandLine) {
+export function commandFromString(commandLine: string) {
     var preLen = CMD_PREFIX.length;
     var lbPos = commandLine.indexOf('[');
     var rbPos = commandLine.indexOf(']');
@@ -62,7 +62,7 @@ export function commandFromString(commandLine) {
     var spaceIdx = cmdInfo.indexOf(' ');
 
     var command = cmdInfo;
-    var properties = {};
+    var properties: {[key: string]: string} = {};
 
     if (spaceIdx > 0) {
         command = cmdInfo.trim().substring(0, spaceIdx);
@@ -90,19 +90,19 @@ export function commandFromString(commandLine) {
     return cmd;
 }
 
-function escapedata(s) : string {
+function escapedata(s: string) : string {
     return s.replace(/%/g, '%AZP25')
             .replace(/\r/g, '%0D')
             .replace(/\n/g, '%0A');
 }
 
-function unescapedata(s) : string {
+function unescapedata(s: string) : string {
     return s.replace(/%0D/g, '\r')
             .replace(/%0A/g, '\n')
             .replace(/%AZP25/g, '%');
 }
 
-function escape(s) : string {
+function escape(s: string) : string {
     return s.replace(/%/g, '%AZP25')
             .replace(/\r/g, '%0D')
             .replace(/\n/g, '%0A')
@@ -110,7 +110,7 @@ function escape(s) : string {
             .replace(/;/g, '%3B');
 }
 
-function unescape(s) : string {
+function unescape(s: string) : string {
     return s.replace(/%0D/g, '\r')
             .replace(/%0A/g, '\n')
             .replace(/%5D/g, ']')

--- a/node/tsconfig.json
+++ b/node/tsconfig.json
@@ -4,12 +4,14 @@
         "module": "commonjs",
         "declaration": true,
         "moduleResolution": "node",
-        "strictNullChecks": true
+        "strictNullChecks": true,
+        "noImplicitAny": true,
     },
     "files": [
         "index.ts",
         "mock-task.ts",
         "mock-run.ts",
-        "mock-test.ts"
+        "mock-test.ts",
+        "types/global.d.ts"
     ]
 }

--- a/node/types/global.d.ts
+++ b/node/types/global.d.ts
@@ -1,0 +1,20 @@
+declare module NodeJS {
+    interface Global {
+      _vsts_task_lib_loaded?: boolean;
+      // proxy related
+      _vsts_task_lib_proxy_url?: string;
+      _vsts_task_lib_proxy_username?: string;
+      _vsts_task_lib_proxy_bypass?: string;
+      _vsts_task_lib_proxy_password?: string;
+      _vsts_task_lib_proxy?: boolean;
+      // cert related
+      _vsts_task_lib_cert_ca?: string;
+      _vsts_task_lib_cert_clientcert?: string;
+      _vsts_task_lib_cert_key?: string;
+      _vsts_task_lib_cert_archive?: string;
+      _vsts_task_lib_cert_archiveFile?: string;
+      _vsts_task_lib_cert_passphrase?: string;
+      _vsts_task_lib_cert?: boolean;
+      _vsts_task_lib_skip_cert_validation?: boolean;
+    }
+  }


### PR DESCRIPTION
These changes add enforcement of `no-implicit-any` in the node library.

It helps make the typing information more concise and potential pitfalls where the parameters are implicitly as `any` .

The changes here are Typescript related and no discernible logic changes.

Declaring the globals all in one location also helps with maintainability. Hopefully this can be documented further and eventually removed?