### PR TITLE
[Mockery replacement] - Replaced mockery with similar adapter

### DIFF
--- a/node/lib-mocker.ts
+++ b/node/lib-mocker.ts
@@ -1,0 +1,213 @@
+const m = require('module');
+
+export interface MockOptions {
+    useCleanCache?: boolean,
+    warnOnReplace?: boolean,
+    warnOnUnregistered?: boolean
+};
+
+let registeredMocks = {};
+let registeredAllowables = new Set<string>();  
+let originalLoader: Function | null = null;
+let originalCache: Record<string, any> = {};
+let options: MockOptions = {};
+let defaultOptions: MockOptions = {
+    useCleanCache: false,
+    warnOnReplace: true,
+    warnOnUnregistered: true
+};
+
+function _getEffectiveOptions(opts: MockOptions): MockOptions {
+    var options: MockOptions = {};
+
+    Object.keys(defaultOptions).forEach(function (key) {
+        if (opts && opts.hasOwnProperty(key)) {
+            options[key] = opts[key];
+        } else {
+            options[key] = defaultOptions[key];
+        }
+    });
+    return options;
+}
+
+/*
+ * Loader function that used when hooking is enabled.
+ * if the requested module is registered as a mock, return the mock.
+ * otherwise, invoke the original loader + put warning in the output.
+ */
+function _hookedLoader(request: string, parent, isMain: boolean) {
+    if (!originalLoader) {
+        throw new Error("Loader has not been hooked");
+    }
+
+    if (registeredMocks.hasOwnProperty(request)) {
+        return registeredMocks[request];
+    }
+
+    if (!registeredAllowables.has(request) && options.warnOnUnregistered) {
+        console.warn("WARNING: loading non-allowed module: " + request);
+    }
+
+    return originalLoader(request, parent, isMain);
+}
+
+
+/**
+ * Remove references to modules in the cache from
+ * their parents' children.
+ */
+function _removeParentReferences(): void {
+    Object.keys(m._cache).forEach(function (k) {
+        if (k.indexOf('\.node') === -1) {
+            // don't touch native modules, because they're special
+            const mod = m._cache[k];
+            const idx = mod?.parent?.children.indexOf(mod);
+            if (idx > -1) {
+                mod.parent.children.splice(idx, 1);
+            }
+        }
+    });
+}
+
+/*
+ * Starting in node 0.12 node won't reload native modules
+ * The reason is that native modules can register themselves to be loaded automatically
+ * This will re-populate the cache with the native modules that have not been mocked
+ */
+function _repopulateNative(): void {
+    Object.keys(originalCache).forEach(function (k) {
+        if (k.indexOf('\.node') > -1 && !m._cache[k]) {
+            m._cache[k] = originalCache[k];
+        }
+    });
+}
+
+/*
+ * Enable function, hooking the Node loader with options.
+ */
+export function enable(opts: MockOptions): void {
+    if (originalLoader) {
+        // Already hooked
+        return;
+    }
+
+    options = _getEffectiveOptions(opts);
+
+    if (options.useCleanCache) {
+        originalCache = m._cache;
+        m._cache = {};
+        _repopulateNative();
+    }
+
+    originalLoader = m._load;
+    m._load = _hookedLoader;
+}
+
+/*
+ * Disables mock loading, reverting to normal 'require' behaviour.
+ */
+export function disable(): void {
+    if (!originalLoader) return;
+
+    if (options.useCleanCache) {
+        Object.keys(m._cache).forEach(function (k) {
+            if (k.indexOf('\.node') > -1 && !originalCache[k]) {
+                originalCache[k] = m._cache[k];
+            }
+        });
+        _removeParentReferences();
+        m._cache = originalCache;
+        originalCache = {};
+    }
+
+    m._load = originalLoader;
+    originalLoader = null;
+}
+
+/*
+* If the clean cache option is in effect, reset the module cache to an empty
+* state. Calling this function when the clean cache option is not in effect
+* will have no ill effects, but will do nothing.
+*/
+export function resetCache(): void {
+    if (options.useCleanCache && originalCache) {
+        _removeParentReferences();
+        m._cache = {};
+        _repopulateNative();
+    }
+}
+
+/*
+ * Enable or disable warnings to the console when previously registered mocks are replaced.
+ */
+export function warnOnReplace(enable: boolean): void {
+    options.warnOnReplace = enable;
+}
+
+/*
+ * Enable or disable warnings to the console when modules are loaded that have
+ * not been registered as a mock.
+ */
+export function warnOnUnregistered(enable: boolean): void {
+    options.warnOnUnregistered = enable;
+}
+
+/*
+ * Register a mock object for the specified module.
+ */
+export function registerMock(mod: string, mock): void {
+    if (options.warnOnReplace && registeredMocks.hasOwnProperty(mod)) {
+        console.warn("WARNING: Replacing existing mock for module: " + mod);
+    }
+    registeredMocks[mod] = mock;
+}
+
+/*
+ * Deregister a mock object for the specified module.
+ */
+export function deregisterMock(mod: string): void {
+    if (registeredMocks.hasOwnProperty(mod)) {
+        delete registeredMocks[mod];
+    }
+}
+
+/*
+ * Deregister all mocks.
+ */
+export function deregisterAll(): void {
+    registeredMocks = {};
+    registeredAllowables = new Set();
+}
+
+/*
+   Register a module as 'allowed'. 
+   This will allow the module to be loaded without mock otherwise a warning would be thrown.
+ */
+export function registerAllowable(mod: string): void {
+    registeredAllowables.add(mod);
+}
+
+/*
+ * Register an array of 'allowed' modules.
+ */
+export function registerAllowables(mods: string[]): void {
+    mods.forEach((mod) => registerAllowable(mod));
+}
+
+/*
+ * Deregister a module as 'allowed'.
+ */
+export function deregisterAllowable(mod: string): void {
+    if (registeredAllowables.hasOwnProperty(mod)) {
+        registeredAllowables.delete(mod);
+    }
+}
+
+/*
+ * Deregister an array of modules as 'allowed'.
+ */
+export function deregisterAllowables(mods) {
+    mods.forEach(function (mod) {
+        deregisterAllowable(mod);
+    });
+}

--- a/node/mock-run.ts
+++ b/node/mock-run.ts
@@ -1,6 +1,6 @@
 import ma = require('./mock-answer');
-import mockery = require('mockery');
 import im = require('./internal');
+import mocker = require('./lib-mocker');
 
 export class TaskMockRunner {
     constructor(taskPath: string) {
@@ -46,7 +46,7 @@ export class TaskMockRunner {
     */
     public registerMock(modName: string, mod: any): void {
         this._moduleCount++;
-        mockery.registerMock(modName, mod);
+        mocker.registerMock(modName, mod);
     }
 
     /**
@@ -69,9 +69,9 @@ export class TaskMockRunner {
     * @returns              void
     */
     public run(noMockTask?: boolean): void {
-        // determine whether to enable mockery
+        // determine whether to enable mocker
         if (!noMockTask || this._moduleCount) {
-            mockery.enable({warnOnUnregistered: false});
+            mocker.enable({warnOnUnregistered: false});
         }
 
         // answers and exports not compatible with "noMockTask" mode
@@ -92,7 +92,7 @@ export class TaskMockRunner {
                     tlm[key] = this._exports[key];
                 });
 
-            mockery.registerMock('azure-pipelines-task-lib/task', tlm);
+            mocker.registerMock('azure-pipelines-task-lib/task', tlm);
         }
 
         // run it

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "5.0.0-preview",
+  "version": "5.0.0-preview.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "4.4.0",
+  "version": "5.0.0-preview",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -40,12 +40,6 @@
       "version": "9.1.1",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
       "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
-      "dev": true
-    },
-    "@types/mockery": {
-      "version": "1.4.29",
-      "resolved": "https://registry.npmjs.org/@types/mockery/-/mockery-1.4.29.tgz",
-      "integrity": "sha1-m6It838H43gP/4Ux0aOOYz+UV6U=",
       "dev": true
     },
     "@types/node": {
@@ -666,11 +660,6 @@
           }
         }
       }
-    },
-    "mockery": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
-      "integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA=="
     },
     "ms": {
       "version": "2.1.3",

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "5.0.0-preview",
+  "version": "5.0.0-preview.0",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "4.4.0",
+  "version": "5.0.0-preview",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",
@@ -28,7 +28,6 @@
   "homepage": "https://github.com/Microsoft/azure-pipelines-task-lib",
   "dependencies": {
     "minimatch": "3.0.5",
-    "mockery": "^2.1.0",
     "q": "^1.5.1",
     "semver": "^5.1.0",
     "shelljs": "^0.8.5",
@@ -38,7 +37,6 @@
   "devDependencies": {
     "@types/minimatch": "3.0.3",
     "@types/mocha": "^9.1.1",
-    "@types/mockery": "^1.4.29",
     "@types/node": "^16.11.39",
     "@types/q": "^1.5.4",
     "@types/semver": "^7.3.4",

--- a/node/test/fakeModules/fakemodule1.ts
+++ b/node/test/fakeModules/fakemodule1.ts
@@ -1,0 +1,7 @@
+export function testFuncLibrary() {
+    return 'testFuncLibrary';
+}
+
+export function otherFuncLibrary() {
+    return 'otherFuncLibrary';
+}

--- a/node/test/fakeModules/fakemodule2.ts
+++ b/node/test/fakeModules/fakemodule2.ts
@@ -1,0 +1,7 @@
+export function testFuncLibrary2() {
+    return 'testFuncLibrary2';
+}
+
+export function otherFuncLibrary2() {
+    return 'otherFuncLibrary2';
+}

--- a/node/test/internalhelpertests.ts
+++ b/node/test/internalhelpertests.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 import * as testutil from './testutil';
 import * as tl from '../_build/task';
 import * as im from '../_build/internal';
-import * as mockery from 'mockery'
+import * as mockery from '../_build/lib-mocker'
 
 describe('Internal Path Helper Tests', function () {
 
@@ -405,7 +405,6 @@ describe('Internal Path Helper Tests', function () {
     
     it('ReportMissingStrings', (done) => {
 
-        mockery.registerAllowable('../_build/internal')
         const fsMock = {
             statSync: function (path) { return null; }
         };

--- a/node/test/internalhelpertests.ts
+++ b/node/test/internalhelpertests.ts
@@ -404,7 +404,7 @@ describe('Internal Path Helper Tests', function () {
     });
     
     it('ReportMissingStrings', (done) => {
-
+        mockery.registerAllowable('../_build/internal')
         const fsMock = {
             statSync: function (path) { return null; }
         };

--- a/node/test/mockertests.ts
+++ b/node/test/mockertests.ts
@@ -1,0 +1,306 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import * as assert from 'assert';
+import * as testutil from './testutil';
+import * as libMocker from '../_build/lib-mocker'
+
+describe('Internal Mock tool Tests', function () {
+    const consoleMocker = new testutil.ConsoleMocker();
+    
+    function resetMockerToInitialState() {
+        consoleMocker.restore();
+        libMocker.deregisterAll();
+        libMocker.disable();
+    }
+
+    beforeEach(function (done) {
+        consoleMocker.mock();
+        done();
+    });
+
+    afterEach(function () {
+        resetMockerToInitialState();
+    });
+
+    it('[warnOnReplace: Passed true via config]. Should write warning when previously registered mocks are replaced.', (done) => {
+        libMocker.enable({ warnOnReplace: true, warnOnUnregistered: false });
+        const fakeModule = require('./fakeModules/fakemodule1');
+        
+        libMocker.registerMock('fakemodule1', fakeModule);
+        libMocker.registerMock('fakemodule1', fakeModule);
+
+        assert.equal(fakeModule.testFuncLibrary(), 'testFuncLibrary');
+        assert.equal(fakeModule.otherFuncLibrary(), 'otherFuncLibrary');
+        
+        const warnings = consoleMocker.getWarns();
+        const errors = consoleMocker.getErrors();
+        assert.equal(warnings.length, 1);
+        assert.equal(errors.length, 0);
+        assert.equal(warnings[0], 'WARNING: Replacing existing mock for module: fakemodule1');
+
+        done();
+    });
+
+    it('[warnOnReplace: Passed true via method]. Should write warning when previously registered mocks are replaced.', (done) => {
+        libMocker.enable({ warnOnUnregistered: false });
+        libMocker.warnOnReplace(true);
+        const fakeModule = require('./fakeModules/fakemodule1');
+        
+        libMocker.registerMock('fakemodule1', fakeModule);
+        libMocker.registerMock('fakemodule1', fakeModule);
+
+        assert.equal(fakeModule.testFuncLibrary(), 'testFuncLibrary');
+        assert.equal(fakeModule.otherFuncLibrary(), 'otherFuncLibrary');
+        
+        const warnings = consoleMocker.getWarns();
+        const errors = consoleMocker.getErrors();
+        assert.equal(warnings.length, 1);
+        assert.equal(errors.length, 0);
+        assert.equal(warnings[0], 'WARNING: Replacing existing mock for module: fakemodule1');
+
+        done();
+    });
+
+    it('[warnOnReplace: Passed false via config]. Should not write warning when previously registered mocks are replaced.', (done) => {
+        libMocker.enable({ warnOnReplace: false, warnOnUnregistered: false });
+        const fakeModule = require('./fakeModules/fakemodule1');
+        
+        libMocker.registerMock('fakemodule1', fakeModule);
+        libMocker.registerMock('fakemodule1', fakeModule);
+
+        assert.equal(fakeModule.testFuncLibrary(), 'testFuncLibrary');
+        assert.equal(fakeModule.otherFuncLibrary(), 'otherFuncLibrary');
+        
+        const warnings = consoleMocker.getWarns();
+        const errors = consoleMocker.getErrors();
+        assert.equal(warnings.length, 0);
+        assert.equal(errors.length, 0);
+
+        libMocker.disable();
+        done();
+    });
+
+    it('[warnOnReplace: Passed false via method]. Should not write warning when previously registered mocks are replaced.', (done) => {
+        libMocker.enable({ warnOnUnregistered: false });
+        libMocker.warnOnReplace(false);
+        const fakeModule = require('./fakeModules/fakemodule1');
+        
+        libMocker.registerMock('fakemodule1', fakeModule);
+        libMocker.registerMock('fakemodule1', fakeModule);
+
+        assert.equal(fakeModule.testFuncLibrary(), 'testFuncLibrary');
+        assert.equal(fakeModule.otherFuncLibrary(), 'otherFuncLibrary');
+        
+        const warnings = consoleMocker.getWarns();
+        const errors = consoleMocker.getErrors();
+        assert.equal(warnings.length, 0);
+        assert.equal(errors.length, 0);
+
+        done();
+    });
+
+    it('[warnOnUnregistered: Passed true via config]. Should write warning when call unregister function.', (done) => {
+        libMocker.enable({ warnOnReplace: false,  warnOnUnregistered: true });
+
+        const fakeModule = require('./fakeModules/fakemodule1');
+        assert.equal(fakeModule.testFuncLibrary(), 'testFuncLibrary');
+        assert.equal(fakeModule.otherFuncLibrary(), 'otherFuncLibrary');
+        
+        const warnings = consoleMocker.getWarns();
+        const errors = consoleMocker.getErrors();
+        assert.equal(warnings.length, 1);
+        assert.equal(errors.length, 0);
+        assert.equal(warnings[0], 'WARNING: loading non-allowed module: ./fakeModules/fakemodule1');
+
+        done();
+    });
+
+    it('[warnOnUnregistered: Passed true via method]. Should write warning when call unregister function.', (done) => {
+        libMocker.enable({ warnOnReplace: false });
+        libMocker.warnOnUnregistered(true);
+
+        const fakeModule = require('./fakeModules/fakemodule1');
+        assert.equal(fakeModule.testFuncLibrary(), 'testFuncLibrary');
+        assert.equal(fakeModule.otherFuncLibrary(), 'otherFuncLibrary');
+        
+        const warnings = consoleMocker.getWarns();
+        const errors = consoleMocker.getErrors();
+        assert.equal(warnings.length, 1);
+        assert.equal(errors.length, 0);
+        assert.equal(warnings[0], 'WARNING: loading non-allowed module: ./fakeModules/fakemodule1');
+
+        done();
+    });
+
+    it('[warnOnUnregistered: Passed false via config]. Should not write warning when call unregister function.', (done) => {
+        libMocker.enable({ warnOnReplace: false, warnOnUnregistered: false });
+
+        const fakeModule = require('./fakeModules/fakemodule1');
+        assert.equal(fakeModule.testFuncLibrary(), 'testFuncLibrary');
+        assert.equal(fakeModule.otherFuncLibrary(), 'otherFuncLibrary');
+        
+        const warnings = consoleMocker.getWarns();
+        const errors = consoleMocker.getErrors();
+        assert.equal(warnings.length, 0);
+        assert.equal(errors.length, 0);
+
+        done();
+    });
+
+    it('[warnOnUnregistered: Passed false via method]. Should not write warning when call unregister function.', (done) => {
+        libMocker.enable({ warnOnReplace: false });
+        libMocker.warnOnUnregistered(false);
+
+        const fakeModule = require('./fakeModules/fakemodule1');
+        assert.equal(fakeModule.testFuncLibrary(), 'testFuncLibrary');
+        assert.equal(fakeModule.otherFuncLibrary(), 'otherFuncLibrary');
+        
+        const warnings = consoleMocker.getWarns();
+        const errors = consoleMocker.getErrors();
+        assert.equal(warnings.length, 0);
+        assert.equal(errors.length, 0);
+
+        done();
+    });
+
+    it('[warnOnUnregistered: register allowable]. Should not write warning when call register function.', (done) => {
+        libMocker.enable({ warnOnReplace: false, warnOnUnregistered: true });
+        libMocker.registerAllowable('./fakeModules/fakemodule1');
+
+        const fakeModule = require('./fakeModules/fakemodule1');
+        assert.equal(fakeModule.testFuncLibrary(), 'testFuncLibrary');
+        assert.equal(fakeModule.otherFuncLibrary(), 'otherFuncLibrary');
+        
+        const warnings = consoleMocker.getWarns();
+        const errors = consoleMocker.getErrors();
+        assert.equal(warnings.length, 0);
+        assert.equal(errors.length, 0);
+
+        done();
+    });
+
+    it('[warnOnUnregistered: register allowables]. Should not write warning when call register function.', (done) => {
+        libMocker.enable({ warnOnReplace: false, warnOnUnregistered: true });
+        libMocker.registerAllowables(['./fakeModules/fakemodule1']);
+
+        const fakeModule = require('./fakeModules/fakemodule1');
+        assert.equal(fakeModule.testFuncLibrary(), 'testFuncLibrary');
+        assert.equal(fakeModule.otherFuncLibrary(), 'otherFuncLibrary');
+        
+        const warnings = consoleMocker.getWarns();
+        const errors = consoleMocker.getErrors();
+        assert.equal(warnings.length, 0);
+        assert.equal(errors.length, 0);
+
+        done();
+    });
+
+    it('[registerMock] Should register mock.', (done) => {
+        libMocker.enable({ warnOnReplace: false, warnOnUnregistered: false });
+        const expepected = {
+            someMockedFunc: 'someMockedFunc',
+            otherMockedFunc: 'otherMockedFunc',
+        }
+
+        libMocker.registerMock('./fakeModules/fakemodule1', {
+            testFuncLibrary: () => expepected.someMockedFunc,
+            otherFuncLibrary: () => expepected.otherMockedFunc,
+        });
+
+        const fakeModule = require('./fakeModules/fakemodule1');
+        assert.equal(fakeModule.testFuncLibrary(), expepected.someMockedFunc);
+        assert.equal(fakeModule.otherFuncLibrary(), expepected.otherMockedFunc);
+        
+        const warnings = consoleMocker.getWarns();
+        assert.equal(warnings.length, 0);
+
+        done();
+    });
+
+    it('[registerMock] Should return not registered function correctly.', (done) => {
+        libMocker.enable({ warnOnReplace: false, warnOnUnregistered: false });
+        const expepected = {
+            someMockedFunc: 'someMockedFunc',
+            otherMockedFunc: 'otherMockedFunc',
+        }
+
+        libMocker.registerMock('./fakeModules/fakemodule1', {
+            testFuncLibrary: () => expepected.someMockedFunc,
+            otherFuncLibrary: () => expepected.otherMockedFunc,
+        });
+
+        const fakeModule = require('./fakeModules/fakemodule1');
+        assert.equal(fakeModule.testFuncLibrary(), expepected.someMockedFunc);
+        assert.equal(fakeModule.otherFuncLibrary(), expepected.otherMockedFunc);
+
+        const fakeModule2 = require('./fakeModules/fakemodule2');
+        assert.equal(fakeModule2.testFuncLibrary2(), 'testFuncLibrary2');
+        assert.equal(fakeModule2.otherFuncLibrary2(), 'otherFuncLibrary2');
+        
+        const warnings = consoleMocker.getWarns();
+        assert.equal(warnings.length, 0);
+
+        done();
+    });
+
+    it('[deregisterMock] Should deregister mock', (done) => {
+        libMocker.enable({ warnOnReplace: false, warnOnUnregistered: false });
+        const expepected = {
+            someMockedFunc: 'someMockedFunc',
+            otherMockedFunc: 'otherMockedFunc',
+        }
+
+        libMocker.registerMock('./fakeModules/fakemodule1', {
+            testFuncLibrary: () => expepected.someMockedFunc,
+            otherFuncLibrary: () => expepected.otherMockedFunc,
+        });
+
+        const fakeModule = require('./fakeModules/fakemodule1');
+        assert.equal(fakeModule.testFuncLibrary(), expepected.someMockedFunc);
+        assert.equal(fakeModule.otherFuncLibrary(), expepected.otherMockedFunc);
+        
+        libMocker.deregisterMock('./fakeModules/fakemodule1');
+        const fakeModuleReRequired = require('./fakeModules/fakemodule1');
+        assert.equal(fakeModuleReRequired.testFuncLibrary(), 'testFuncLibrary');
+        assert.equal(fakeModuleReRequired.otherFuncLibrary(), 'otherFuncLibrary');
+        
+
+        const warnings = consoleMocker.getWarns();
+        const errors = consoleMocker.getErrors();
+        assert.equal(warnings.length, 0);
+        assert.equal(errors.length, 0);
+
+        done();
+    });
+
+    it('[deregisterAll] Should deregister all mocks', (done) => {
+        libMocker.enable({ warnOnReplace: false, warnOnUnregistered: true });
+        const expepected = {
+            someMockedFunc: 'someMockedFunc',
+            otherMockedFunc: 'otherMockedFunc',
+        }
+
+        libMocker.registerMock('./fakeModules/fakemodule1', {
+            testFuncLibrary: () => expepected.someMockedFunc,
+            otherFuncLibrary: () => expepected.otherMockedFunc,
+        });
+
+        const fakeModule = require('./fakeModules/fakemodule1');
+        assert.equal(fakeModule.testFuncLibrary(), expepected.someMockedFunc);
+        assert.equal(fakeModule.otherFuncLibrary(), expepected.otherMockedFunc);
+        
+        libMocker.deregisterAll();
+        const fakeModuleReRequired = require('./fakeModules/fakemodule1');
+        assert.equal(fakeModuleReRequired.testFuncLibrary(), 'testFuncLibrary');
+        assert.equal(fakeModuleReRequired.otherFuncLibrary(), 'otherFuncLibrary');
+        
+
+        const warnings = consoleMocker.getWarns();
+        const errors = consoleMocker.getErrors();
+        assert.equal(warnings.length, 1);
+        assert.equal(errors.length, 0);
+
+        done();
+    });
+});

--- a/node/test/testutil.ts
+++ b/node/test/testutil.ts
@@ -123,3 +123,55 @@ export function createSymlinkDir(real: string, link: string): void {
         fs.symlinkSync(real, link);
     }
 };
+export class ConsoleMocker {
+    private _originalConsoleLog?: null | typeof console.log = null;
+    private _originalConsoleWarn?: null | typeof console.warn = null;
+    private _originalConsoleError?: null | typeof console.error = null;
+    private _logs: string[] = [];
+    private _warns: string[] = [];
+    private _errors: string[] = [];
+
+    constructor() {
+        this.initialize();
+    }
+
+    private initialize() {
+        this._originalConsoleLog = console.log;
+        this._originalConsoleWarn = console.warn;
+        this._originalConsoleError = console.error;
+    }
+    
+    public mock() {
+        console.log = (message?: string, ...optionalParams: any[]) => {
+            this._logs.push(message);
+        };
+        console.warn = (message?: string, ...optionalParams: any[]) => {
+            this._warns.push(message);
+        };
+        console.error = (message?: string, ...optionalParams: any[]) => {
+            this._errors.push(message);
+        };
+    }
+
+    public restore() {
+        if (this._originalConsoleLog) console.log = this._originalConsoleLog;
+        if (this._originalConsoleWarn) console.warn = this._originalConsoleWarn;
+        if (this._originalConsoleError) console.error = this._originalConsoleError;
+
+        this._logs = [];
+        this._warns = [];
+        this._errors = [];
+    }
+
+    public getLogs(): string[] {
+        return this._logs;
+    }
+
+    public getWarns(): string[] {
+        return this._warns;
+    }
+
+    public getErrors(): string[] {
+        return this._errors;
+    }
+}

--- a/node/test/tsconfig.json
+++ b/node/test/tsconfig.json
@@ -24,6 +24,9 @@
         "mocktests.ts",
         "retrytests.ts",
         "isuncpathtests.ts",
-        "gethttpproxytests.ts"
+        "gethttpproxytests.ts",
+        "mockertests.ts",
+        "fakeModules/fakemodule1.ts",
+        "fakeModules/fakemodule2.ts"
     ]
 }


### PR DESCRIPTION
- Replaced Mockery test-lib since it has vulnerabilities and is no longer maintained
- Replaced with self-written adapter inspired by mockery for backward compatibility with tasks.
- All methods which are not used in the tasks are not implemented since they shouldn't be used separately from toolrunner.
- Added unit Tests
- Task-Lib version was bumped to 5.0.0-preview
- The lib was fully tested with all node-based tasks from azure-pipelines-task-lib repository