### PR TITLE
Allow to publish changes from release branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,7 +48,13 @@ jobs:
         npm publish || true # Ignore publish failures, usually will happen because package already exists
     displayName: npm publish
     workingDirectory: node/_build
-    condition: and(succeeded(), in(variables['build.reason'], 'IndividualCI', 'BatchedCI', 'Manual'), in(variables['build.sourcebranch'], 'refs/heads/master'))
+    condition: and(
+      succeeded(), 
+      in(variables['build.reason'], 'IndividualCI', 'BatchedCI', 'Manual'),
+      or(
+        in(variables['build.sourcebranch'], 'refs/heads/master')),
+        startsWith(variables['build.sourcebranch'], 'refs/heads/releases'))
+      ) 
     env:
       NPM_TOKEN: $(npm-automation.token)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,9 +52,9 @@ jobs:
       succeeded(), 
       in(variables['build.reason'], 'IndividualCI', 'BatchedCI', 'Manual'),
       or(
-        in(variables['build.sourcebranch'], 'refs/heads/master')),
-        startsWith(variables['build.sourcebranch'], 'refs/heads/releases'))
-      ) 
+        in(variables['build.sourcebranch'], 'refs/heads/master'),
+        startsWith(variables['build.sourcebranch'], 'refs/heads/releases')
+      ))
     env:
       NPM_TOKEN: $(npm-automation.token)
 


### PR DESCRIPTION
Since we started to use release branch for mockery replacement changes and node20 migration we need to allow publish the changes from releases/ branches