### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 10947: Build ID 22418181

### DIFF
--- a/powershell/VstsTaskSdk/Strings/resources.resjson/de-DE/resources.resjson
+++ b/powershell/VstsTaskSdk/Strings/resources.resjson/de-DE/resources.resjson
@@ -6,7 +6,7 @@
   "loc.messages.PSLIB_EnumeratingSubdirectoriesFailedForPath0": "Fehler beim Aufzählen von Unterverzeichnissen für den folgenden Pfad: \"{0}\"",
   "loc.messages.PSLIB_FileNotFound0": "Die Datei wurde nicht gefunden: \"{0}\".",
   "loc.messages.PSLIB_Input0": "\"{0}\"-Eingabe",
-  "loc.messages.PSLIB_InvalidPattern0": "Der Pfad darf nicht mit einem Verzeichnistrennzeichen enden: „{0}“",
+  "loc.messages.PSLIB_InvalidPattern0": "Ungültiges Muster: \"{0}\"",
   "loc.messages.PSLIB_LeafPathNotFound0": "Der Blattpfad wurde nicht gefunden: \"{0}\".",
   "loc.messages.PSLIB_PathLengthNotReturnedFor0": "Fehler bei der Normalisierung bzw. Erweiterung des Pfads. Die Pfadlänge wurde vom Kernel32-Subsystem nicht zurückgegeben für: \"{0}\"",
   "loc.messages.PSLIB_PathNotFound0": "Der Pfad wurde nicht gefunden: \"{0}\".",

--- a/powershell/VstsTaskSdk/Strings/resources.resjson/es-ES/resources.resjson
+++ b/powershell/VstsTaskSdk/Strings/resources.resjson/es-ES/resources.resjson
@@ -6,7 +6,7 @@
   "loc.messages.PSLIB_EnumeratingSubdirectoriesFailedForPath0": "No se pudieron enumerar los subdirectorios de la ruta de acceso: '{0}'",
   "loc.messages.PSLIB_FileNotFound0": "Archivo no encontrado: '{0}'",
   "loc.messages.PSLIB_Input0": "Entrada '{0}'",
-  "loc.messages.PSLIB_InvalidPattern0": "La ruta de acceso no puede terminar con un carácter separador de directorios: '{0}'",
+  "loc.messages.PSLIB_InvalidPattern0": "Patrón no válido: '{0}'",
   "loc.messages.PSLIB_LeafPathNotFound0": "No se encuentra la ruta de acceso de la hoja: '{0}'",
   "loc.messages.PSLIB_PathLengthNotReturnedFor0": "No se pudo normalizar o expandir la ruta de acceso. El subsistema Kernel32 no devolvió la longitud de la ruta de acceso para: '{0}'",
   "loc.messages.PSLIB_PathNotFound0": "No se encuentra la ruta de acceso: '{0}'",

--- a/powershell/VstsTaskSdk/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/powershell/VstsTaskSdk/Strings/resources.resjson/fr-FR/resources.resjson
@@ -6,7 +6,7 @@
   "loc.messages.PSLIB_EnumeratingSubdirectoriesFailedForPath0": "Échec de l'énumération des sous-répertoires pour le chemin : '{0}'",
   "loc.messages.PSLIB_FileNotFound0": "Fichier introuvable : {0}.",
   "loc.messages.PSLIB_Input0": "Entrée '{0}'",
-  "loc.messages.PSLIB_InvalidPattern0": "Le chemin d’accès ne peut pas se terminer par un caractère de séparateur de répertoire : « {0} »",
+  "loc.messages.PSLIB_InvalidPattern0": "Modèle non valide : '{0}'",
   "loc.messages.PSLIB_LeafPathNotFound0": "Le chemin feuille est introuvable : '{0}'",
   "loc.messages.PSLIB_PathLengthNotReturnedFor0": "Échec de la normalisation/l'expansion du chemin. La longueur du chemin n'a pas été retournée par le sous-système Kernel32 pour : '{0}'",
   "loc.messages.PSLIB_PathNotFound0": "Chemin introuvable : '{0}'",

--- a/powershell/VstsTaskSdk/Strings/resources.resjson/it-IT/resources.resjson
+++ b/powershell/VstsTaskSdk/Strings/resources.resjson/it-IT/resources.resjson
@@ -6,7 +6,7 @@
   "loc.messages.PSLIB_EnumeratingSubdirectoriesFailedForPath0": "L'enumerazione delle sottodirectory per il percorso '{0}' non è riuscita",
   "loc.messages.PSLIB_FileNotFound0": "File non trovato: '{0}'",
   "loc.messages.PSLIB_Input0": "Input di '{0}'",
-  "loc.messages.PSLIB_InvalidPattern0": "Il percorso non può terminare con un carattere separatore di directory: '{0}'",
+  "loc.messages.PSLIB_InvalidPattern0": "Criterio non valido: '{0}'",
   "loc.messages.PSLIB_LeafPathNotFound0": "Percorso foglia non trovato: '{0}'",
   "loc.messages.PSLIB_PathLengthNotReturnedFor0": "La normalizzazione o l'espansione del percorso non è riuscita. Il sottosistema Kernel32 non ha restituito la lunghezza del percorso per '{0}'",
   "loc.messages.PSLIB_PathNotFound0": "Percorso non trovato: '{0}'",

--- a/powershell/VstsTaskSdk/Strings/resources.resjson/ja-JP/resources.resjson
+++ b/powershell/VstsTaskSdk/Strings/resources.resjson/ja-JP/resources.resjson
@@ -6,7 +6,7 @@
   "loc.messages.PSLIB_EnumeratingSubdirectoriesFailedForPath0": "パス '{0}' のサブディレクトリを列挙できませんでした",
   "loc.messages.PSLIB_FileNotFound0": "ファイルが見つかりません: '{0}'",
   "loc.messages.PSLIB_Input0": "'{0}' 入力",
-  "loc.messages.PSLIB_InvalidPattern0": "パスの末尾をディレクトリ区切り文字にすることはできません: '{0}'",
+  "loc.messages.PSLIB_InvalidPattern0": "使用できないパターンです: '{0}'",
   "loc.messages.PSLIB_LeafPathNotFound0": "リーフ パスが見つかりません: '{0}'",
   "loc.messages.PSLIB_PathLengthNotReturnedFor0": "パスの正規化/展開に失敗しました。Kernel32 サブシステムからパス '{0}' の長さが返されませんでした",
   "loc.messages.PSLIB_PathNotFound0": "パスが見つかりません: '{0}'",

--- a/powershell/VstsTaskSdk/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/powershell/VstsTaskSdk/Strings/resources.resjson/ko-KR/resources.resjson
@@ -6,7 +6,7 @@
   "loc.messages.PSLIB_EnumeratingSubdirectoriesFailedForPath0": "경로에 대해 하위 디렉터리를 열거하지 못함: '{0}'",
   "loc.messages.PSLIB_FileNotFound0": "{0} 파일을 찾을 수 없습니다.",
   "loc.messages.PSLIB_Input0": "'{0}' 입력",
-  "loc.messages.PSLIB_InvalidPattern0": "경로는 디렉터리 구분 문자로 끝날 수 없습니다. '{0}'",
+  "loc.messages.PSLIB_InvalidPattern0": "잘못된 패턴: '{0}'",
   "loc.messages.PSLIB_LeafPathNotFound0": "Leaf 경로를 찾을 수 없음: '{0}'",
   "loc.messages.PSLIB_PathLengthNotReturnedFor0": "경로 정규화/확장에 실패했습니다. 다음에 대해 Kernel32 subsystem에서 경로 길이를 반환하지 않음: '{0}'",
   "loc.messages.PSLIB_PathNotFound0": "경로를 찾을 수 없음: '{0}'",

--- a/powershell/VstsTaskSdk/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/powershell/VstsTaskSdk/Strings/resources.resjson/ru-RU/resources.resjson
@@ -6,7 +6,7 @@
   "loc.messages.PSLIB_EnumeratingSubdirectoriesFailedForPath0": "Сбой перечисления подкаталогов для пути: \"{0}\".",
   "loc.messages.PSLIB_FileNotFound0": "Файл не найден: \"{0}\"",
   "loc.messages.PSLIB_Input0": "Входные данные \"{0}\".",
-  "loc.messages.PSLIB_InvalidPattern0": "Путь не может заканчиваться символом разделителя каталогов: \"{0}\"",
+  "loc.messages.PSLIB_InvalidPattern0": "Недопустимый шаблон: \"{0}\".",
   "loc.messages.PSLIB_LeafPathNotFound0": "Путь к конечному объекту не найден: \"{0}\".",
   "loc.messages.PSLIB_PathLengthNotReturnedFor0": "Сбой нормализации и расширения пути. Длина пути не была возвращена подсистемой Kernel32 для: \"{0}\".",
   "loc.messages.PSLIB_PathNotFound0": "Путь не найден: \"{0}\".",

--- a/powershell/VstsTaskSdk/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/powershell/VstsTaskSdk/Strings/resources.resjson/zh-CN/resources.resjson
@@ -6,7 +6,7 @@
   "loc.messages.PSLIB_EnumeratingSubdirectoriesFailedForPath0": "枚举路径的子目录失败:“{0}”",
   "loc.messages.PSLIB_FileNotFound0": "找不到文件: {0}。",
   "loc.messages.PSLIB_Input0": "“{0}”输入",
-  "loc.messages.PSLIB_InvalidPattern0": "路径不能以目录分隔符结尾:“{0}”",
+  "loc.messages.PSLIB_InvalidPattern0": "无效的模式:“{0}”",
   "loc.messages.PSLIB_LeafPathNotFound0": "找不到叶路径:“{0}”",
   "loc.messages.PSLIB_PathLengthNotReturnedFor0": "路径规范化/扩展失败。路径长度不是由“{0}”的 Kernel32 子系统返回的",
   "loc.messages.PSLIB_PathNotFound0": "找不到路径:“{0}”",

--- a/powershell/VstsTaskSdk/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/powershell/VstsTaskSdk/Strings/resources.resjson/zh-TW/resources.resjson
@@ -6,7 +6,7 @@
   "loc.messages.PSLIB_EnumeratingSubdirectoriesFailedForPath0": "為路徑列舉子目錄失敗: '{0}'",
   "loc.messages.PSLIB_FileNotFound0": "找不到檔案: '{0}'",
   "loc.messages.PSLIB_Input0": "'{0}' 輸入",
-  "loc.messages.PSLIB_InvalidPattern0": "路徑不能以目錄分隔符號結尾: '{0}'",
+  "loc.messages.PSLIB_InvalidPattern0": "模式無效: '{0}'",
   "loc.messages.PSLIB_LeafPathNotFound0": "找不到分葉路徑: '{0}'",
   "loc.messages.PSLIB_PathLengthNotReturnedFor0": "路徑正規化/展開失敗。Kernel32 子系統未傳回 '{0}' 的路徑長度",
   "loc.messages.PSLIB_PathNotFound0": "找不到路徑: '{0}'",


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.