### PR TITLE
Introduce tl.getNodeMajorVersion

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -57,3 +57,7 @@ Backported from ver.`3.4.0`:
 ## 4.6.0
 
 - Replaced deprecated "sync-request" lib and Added new Async methods - [#932](https://github.com/microsoft/azure-pipelines-task-lib/pull/932)
+
+## 4.6.1
+
+- Added `getNodeMajorVersion` [#979](https://github.com/microsoft/azure-pipelines-task-lib/pull/979)

--- a/node/Strings/resources.resjson/en-US/resources.resjson
+++ b/node/Strings/resources.resjson/en-US/resources.resjson
@@ -31,5 +31,6 @@
   "loc.messages.LIB_UseFirstGlobMatch": "Multiple workspace matches. using first.",
   "loc.messages.LIB_MergeTestResultNotSupported": "Merging test results from multiple files to one test run is not supported on this version of build agent for OSX/Linux, each test result file will be published as a separate test run in VSO/TFS.",
   "loc.messages.LIB_PlatformNotSupported": "Platform not supported: %s",
-  "loc.messages.LIB_CopyFileFailed": "Error while copying the file. Attempts left: %s"
+  "loc.messages.LIB_CopyFileFailed": "Error while copying the file. Attempts left: %s",
+  "loc.messages.LIB_UndefinedNodeVersion": "Node version is undefined."
 }

--- a/node/lib.json
+++ b/node/lib.json
@@ -32,6 +32,7 @@
     "LIB_UseFirstGlobMatch": "Multiple workspace matches. using first.",
     "LIB_MergeTestResultNotSupported": "Merging test results from multiple files to one test run is not supported on this version of build agent for OSX/Linux, each test result file will be published as a separate test run in VSO/TFS.",
     "LIB_PlatformNotSupported": "Platform not supported: %s",
-    "LIB_CopyFileFailed": "Error while copying the file. Attempts left: %s"
+    "LIB_CopyFileFailed": "Error while copying the file. Attempts left: %s",
+    "LIB_UndefinedNodeVersion": "Node version is undefined."
   } 
 }

--- a/node/mock-answer.ts
+++ b/node/mock-answer.ts
@@ -14,6 +14,7 @@ export interface TaskLibAnswers {
     find?: { [key: string]: string[] },
     findMatch?: { [key: string]: string[] },
     getPlatform?: { [key: string]: task.Platform },
+    getNodeMajorVersion?: { [key: string]: Number },
     getAgentMode?: { [key: string]: task.AgentHostedMode },
     legacyFindFiles?: { [key: string]: string[] },
     ls?: { [key: string]: string },

--- a/node/mock-task.ts
+++ b/node/mock-task.ts
@@ -222,6 +222,10 @@ export function getPlatform(): task.Platform {
     return mock.getResponse('getPlatform', 'getPlatform', module.exports.debug);
 }
 
+export function getNodeMajorVersion(): Number {
+    return mock.getResponse('getNodeMajorVersion', 'getNodeMajorVersion', module.exports.debug);
+}
+
 export function getAgentMode(): task.AgentHostedMode {
     return mock.getResponse('getAgentMode', 'getAgentMode', module.exports.debug);
 }

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -33,9 +33,10 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.11.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.39.tgz",
-      "integrity": "sha512-K0MsdV42vPwm9L6UwhIxMAOmcvH/1OoVkZyCgEtVu4Wx7sElGloy/W7kMBNe/oJ7V/jW9BVt1F6RahH6e7tPXw=="
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "dev": true
     },
     "@types/q": {
       "version": "1.5.4",

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",

--- a/node/task.ts
+++ b/node/task.ts
@@ -707,9 +707,9 @@ export function getPlatform(): Platform {
  * @returns {Number} Node's major version.
  */
 export function getNodeMajorVersion(): Number {
-    const version = process.versions.node;
+    const version = process?.versions?.node;
     if (!version) {
-        return NaN;
+        throw new Error(loc('LIB_UndefinedNodeVersion'));
     }
 
     const parts = version.split('.').map(Number);

--- a/node/task.ts
+++ b/node/task.ts
@@ -703,6 +703,24 @@ export function getPlatform(): Platform {
 }
 
 /**
+ * Resolves major version of Node.js engine used by the agent.
+ * @returns {Number} Node's major version.
+ */
+export function getNodeMajorVersion(): Number {
+    const version = process.versions.node;
+    if (!version) {
+        return NaN;
+    }
+
+    const parts = version.split('.').map(Number);
+    if (parts.length < 1) {
+        return NaN;
+    }
+
+    return parts[0];
+}
+
+/**
  * Return hosted type of Agent
  * @returns {AgentHostedMode}
  */


### PR DESCRIPTION
This PR adds new function `getNodeMajorVersion` to tasks.ts.

**To do:**
- [x] Bump up package version
- [x] Update changelog