### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 10947: Build ID 23093005

### DIFF
--- a/node/Strings/resources.resjson/de-DE/resources.resjson
+++ b/node/Strings/resources.resjson/de-DE/resources.resjson
@@ -31,5 +31,6 @@
   "loc.messages.LIB_UseFirstGlobMatch": "Mehrere Arbeitsbereichübereinstimmungen. Die erste Übereinstimmung wird verwendet.",
   "loc.messages.LIB_MergeTestResultNotSupported": "Das Mergen von Testergebnissen aus mehreren Dateien in einen Testlauf wird von dieser Version des Build-Agents für OSX/Linux nicht unterstützt. Jede Testergebnisdatei wird als separater Testlauf in VSO/TFS veröffentlicht.",
   "loc.messages.LIB_PlatformNotSupported": "Plattform wird nicht unterstützt: %s",
-  "loc.messages.LIB_CopyFileFailed": "Error while copying the file. Attempts left: %s"
+  "loc.messages.LIB_CopyFileFailed": "Fehler beim Kopieren der Datei. Verbleibende Versuche: %s",
+  "loc.messages.LIB_UndefinedNodeVersion": "Die Knotenversion ist nicht definiert."
 }

--- a/node/Strings/resources.resjson/es-ES/resources.resjson
+++ b/node/Strings/resources.resjson/es-ES/resources.resjson
@@ -31,5 +31,6 @@
   "loc.messages.LIB_UseFirstGlobMatch": "Hay varias coincidencias en el área de trabajo. Se usará la primera.",
   "loc.messages.LIB_MergeTestResultNotSupported": "Esta versión del agente de compilación para OSX/Linux no admite la fusión mediante combinación de resultados de pruebas de varios archivos en una serie de pruebas. Cada archivo de resultados de pruebas se publicará como una serie de pruebas diferente en VSO/TFS.",
   "loc.messages.LIB_PlatformNotSupported": "No se admite la plataforma: %s",
-  "loc.messages.LIB_CopyFileFailed": "Error while copying the file. Attempts left: %s"
+  "loc.messages.LIB_CopyFileFailed": "Error al copiar el archivo. Intentos restantes: %s",
+  "loc.messages.LIB_UndefinedNodeVersion": "La versión del nodo no está definida."
 }

--- a/node/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/node/Strings/resources.resjson/fr-FR/resources.resjson
@@ -31,5 +31,6 @@
   "loc.messages.LIB_UseFirstGlobMatch": "Plusieurs espaces de travail correspondants. Utilisation du premier d'entre eux.",
   "loc.messages.LIB_MergeTestResultNotSupported": "La fusion des résultats des tests de plusieurs fichiers en une seule série de tests n'est pas prise en charge dans cette version de l'agent de build pour OSX/Linux. Chaque fichier de résultats des tests est publié en tant que série de tests distincte dans VSO/TFS.",
   "loc.messages.LIB_PlatformNotSupported": "Plateforme non prise en charge : %s",
-  "loc.messages.LIB_CopyFileFailed": "Error while copying the file. Attempts left: %s"
+  "loc.messages.LIB_CopyFileFailed": "Erreur durant la copie du fichier. Tentatives restantes : %s",
+  "loc.messages.LIB_UndefinedNodeVersion": "La version du nœud n’est pas définie."
 }

--- a/node/Strings/resources.resjson/it-IT/resources.resjson
+++ b/node/Strings/resources.resjson/it-IT/resources.resjson
@@ -31,5 +31,6 @@
   "loc.messages.LIB_UseFirstGlobMatch": "Sono presenti più corrispondenze dell'area di lavoro. Verrà usata la prima.",
   "loc.messages.LIB_MergeTestResultNotSupported": "L'unione di più file risultanti da un'unica esecuzione dei test non è supportata in questa versione dell'agente di compilazione per OS X/Linux. Ogni file dei risultati del test verrà pubblicato come esecuzione dei test separata in VSO/TFS.",
   "loc.messages.LIB_PlatformNotSupported": "Piattaforma non supportata: %s",
-  "loc.messages.LIB_CopyFileFailed": "Si è verificato un errore durante la copia del file. Tentativi rimasti: %s"
+  "loc.messages.LIB_CopyFileFailed": "Si è verificato un errore durante la copia del file. Tentativi rimasti: %s",
+  "loc.messages.LIB_UndefinedNodeVersion": "La versione del nodo non è definita."
 }

--- a/node/Strings/resources.resjson/ja-JP/resources.resjson
+++ b/node/Strings/resources.resjson/ja-JP/resources.resjson
@@ -31,5 +31,6 @@
   "loc.messages.LIB_UseFirstGlobMatch": "複数のワークスペースが一致します。最初のワークスペースが使用されます。",
   "loc.messages.LIB_MergeTestResultNotSupported": "複数のファイルからのテスト結果を 1 つのテスト実行にマージする処理は、OSX/Linux 用のビルド エージェントのこのバージョンではサポートされていません。各テスト結果ファイルが VSO/TFS で別個のテスト実行として発行されます。",
   "loc.messages.LIB_PlatformNotSupported": "プラットフォームがサポートされていません: %s",
-  "loc.messages.LIB_CopyFileFailed": "Error while copying the file. Attempts left: %s"
+  "loc.messages.LIB_CopyFileFailed": "ファイルのコピー中にエラーが発生しました。残りの試行回数: %s",
+  "loc.messages.LIB_UndefinedNodeVersion": "ノードのバージョンが定義されていません。"
 }

--- a/node/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/node/Strings/resources.resjson/ko-KR/resources.resjson
@@ -31,5 +31,6 @@
   "loc.messages.LIB_UseFirstGlobMatch": "여러 작업 영역이 일치합니다. 첫 번째 작업 영역을 사용하세요.",
   "loc.messages.LIB_MergeTestResultNotSupported": "이 OSX/Linux용 빌드 에이전트 버전에서 여러 파일의 테스트 결과를 하나의 테스트 실행으로 병합하는 것을 지원하지 않습니다. 각 테스트 결과 파일은 VSO/TFS에서 별도의 테스트 실행으로 게시됩니다.",
   "loc.messages.LIB_PlatformNotSupported": "지원되지 않는 플랫폼: %s",
-  "loc.messages.LIB_CopyFileFailed": "파일을 복사하는 동안 오류가 발생했습니다. 남은 시도 횟수: %s"
+  "loc.messages.LIB_CopyFileFailed": "파일을 복사하는 동안 오류가 발생했습니다. 남은 시도 횟수: %s",
+  "loc.messages.LIB_UndefinedNodeVersion": "노드 버전이 정의되지 않았습니다."
 }

--- a/node/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/node/Strings/resources.resjson/ru-RU/resources.resjson
@@ -31,5 +31,6 @@
   "loc.messages.LIB_UseFirstGlobMatch": "Несколько рабочих областей совпадает, использована первая рабочая область.",
   "loc.messages.LIB_MergeTestResultNotSupported": "Объединение результатов тестов из нескольких файлов в один тестовый запуск не поддерживается в этой версии агента сборки для OSX/Linux. Каждый файл результатов теста будет опубликован в качестве отдельного тестового запуска в VSO/TFS.",
   "loc.messages.LIB_PlatformNotSupported": "Платформа не поддерживается: %s",
-  "loc.messages.LIB_CopyFileFailed": "Ошибка при копировании файла. Оставшееся число попыток: %s."
+  "loc.messages.LIB_CopyFileFailed": "Ошибка при копировании файла. Оставшееся число попыток: %s.",
+  "loc.messages.LIB_UndefinedNodeVersion": "Версия узла не определена."
 }

--- a/node/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/node/Strings/resources.resjson/zh-CN/resources.resjson
@@ -31,5 +31,6 @@
   "loc.messages.LIB_UseFirstGlobMatch": "出现多个工作区匹配时，使用第一个。",
   "loc.messages.LIB_MergeTestResultNotSupported": "此版本的 OSX/Linux 生成代理不支持来自某个测试运行的多文件合并测试结果，在 VSO/TFS 中，每个测试结果文件都将作为单独的测试运行进行发布。",
   "loc.messages.LIB_PlatformNotSupported": "平台不受支持: %s",
-  "loc.messages.LIB_CopyFileFailed": "复制文件时出错。剩余尝试次数: %s"
+  "loc.messages.LIB_CopyFileFailed": "复制文件时出错。剩余尝试次数: %s",
+  "loc.messages.LIB_UndefinedNodeVersion": "节点版本未定义。"
 }

--- a/node/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/node/Strings/resources.resjson/zh-TW/resources.resjson
@@ -31,5 +31,6 @@
   "loc.messages.LIB_UseFirstGlobMatch": "多個工作區相符。請先使用。",
   "loc.messages.LIB_MergeTestResultNotSupported": "OSX/Linux 的此版本組建代理程式不支援將多個檔案的測試結果合併至單一測試回合，每個測試結果檔案將作為個別測試回合在 VSO/TFS 中發行。",
   "loc.messages.LIB_PlatformNotSupported": "不支援的平台: %s",
-  "loc.messages.LIB_CopyFileFailed": "複製檔案時發生錯誤。剩餘嘗試次數: %s"
+  "loc.messages.LIB_CopyFileFailed": "複製檔案時發生錯誤。剩餘嘗試次數: %s",
+  "loc.messages.LIB_UndefinedNodeVersion": "未定義節點版本。"
 }


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.