### PR TITLE
Adding group and endgroup log functions

### DIFF
--- a/node/internal.ts
+++ b/node/internal.ts
@@ -4,6 +4,7 @@ import os = require('os');
 import minimatch = require('minimatch');
 import util = require('util');
 import tcm = require('./taskcommand');
+import lcm = require('./logcommand');
 import vm = require('./vault');
 import semver = require('semver');
 import crypto = require('crypto');
@@ -292,6 +293,23 @@ export function _error(message: string): void {
 
 export function _debug(message: string): void {
     _command('task.debug', null, message);
+}
+
+//-----------------------------------------------------
+// Log Helpers
+//-----------------------------------------------------
+
+export function _logCommand(command: string, name: string) {
+    var logCmd = new lcm.LogCommand(command, name);
+    _writeLine(logCmd.toString());
+}
+
+export function _group(name: string): void {
+    _logCommand('group', name)
+}
+
+export function _endGroup(): void {
+    _logCommand('endgroup', null)
 }
 
 // //-----------------------------------------------------

--- a/node/logcommand.ts
+++ b/node/logcommand.ts
@@ -1,0 +1,65 @@
+//
+// Command Format:
+//    ##[group]name
+//    ##[endgroup]
+//    
+// Examples:
+//    ##[group]Available contexts
+//    ##[endgroup]
+//
+let CMD_PREFIX = '##[';
+
+export class LogCommand {
+    constructor(command, name) {
+        if (!command) {
+            command = 'missing.command';
+        }
+
+        this.command = command;
+        this.name = name;
+    }
+
+    public command: string;
+    public name: string;
+
+    public toString() {
+        var cmdStr = CMD_PREFIX + this.command;
+
+        cmdStr += ']';
+        
+        // safely append the name - avoid blowing up when attempting to
+        // call .replace() if name is not a string for some reason
+        let name: string = '' + (this.name || '');
+        cmdStr += escapedata(name);
+
+        return cmdStr;
+    }
+}
+
+function escapedata(s) : string {
+    return s.replace(/%/g, '%AZP25')
+            .replace(/\r/g, '%0D')
+            .replace(/\n/g, '%0A');
+}
+
+function unescapedata(s) : string {
+    return s.replace(/%0D/g, '\r')
+            .replace(/%0A/g, '\n')
+            .replace(/%AZP25/g, '%');
+}
+
+function escape(s) : string {
+    return s.replace(/%/g, '%AZP25')
+            .replace(/\r/g, '%0D')
+            .replace(/\n/g, '%0A')
+            .replace(/]/g, '%5D')
+            .replace(/;/g, '%3B');
+}
+
+function unescape(s) : string {
+    return s.replace(/%0D/g, '\r')
+            .replace(/%0A/g, '\n')
+            .replace(/%5D/g, ']')
+            .replace(/%3B/g, ';')
+            .replace(/%AZP25/g, '%');
+}

--- a/node/task.ts
+++ b/node/task.ts
@@ -113,7 +113,7 @@ process.on('uncaughtException', (err: Error) => {
 
 //
 // Catching unhandled rejections from promises and rethrowing them as exceptions
-// For example, a promise that is rejected but not handled by a .catch() handler in node 10 
+// For example, a promise that is rejected but not handled by a .catch() handler in node 10
 // doesn't cause an uncaughtException but causes in Node 16.
 // For types definitions(Error | Any) see https://nodejs.org/docs/latest-v16.x/api/process.html#event-unhandledrejection
 //
@@ -632,6 +632,7 @@ export function setTaskVariable(name: string, val: string, secret: boolean = fal
 export const command = im._command;
 export const warning = im._warning;
 export const error = im._error;
+export const debug = im._debug;
 
 //-----------------------------------------------------
 // Log Helpers
@@ -1954,7 +1955,7 @@ export interface ProxyConfiguration {
     proxyUrl: string;
     /**
      * Proxy URI formated as: protocol://username:password@hostname:port
-     * 
+     *
      * For tools that require setting proxy configuration in the single environment variable
      */
     proxyFormattedUrl: string;

--- a/node/task.ts
+++ b/node/task.ts
@@ -7,6 +7,7 @@ import os = require('os');
 import minimatch = require('minimatch');
 import im = require('./internal');
 import tcm = require('./taskcommand');
+import lcm = require('./logcommand');
 import trm = require('./toolrunner');
 import semver = require('semver');
 
@@ -631,7 +632,14 @@ export function setTaskVariable(name: string, val: string, secret: boolean = fal
 export const command = im._command;
 export const warning = im._warning;
 export const error = im._error;
-export const debug = im._debug;
+
+//-----------------------------------------------------
+// Log Helpers
+//-----------------------------------------------------
+
+export const logCommand = im._logCommand;
+export const group = im._group;
+export const endGroup = im._endGroup;
 
 //-----------------------------------------------------
 // Disk Functions
@@ -2378,6 +2386,7 @@ export function updateReleaseName(name: string) {
 exports.TaskCommand = tcm.TaskCommand;
 exports.commandFromString = tcm.commandFromString;
 exports.ToolRunner = trm.ToolRunner;
+exports.LogCommand = lcm.LogCommand;
 
 //-----------------------------------------------------
 // Validation Checks


### PR DESCRIPTION
- Fixes: #995

Add functionality to call [formatting commands](https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=powershell#formatting-commands) in Azure DevOps Pipeline tasks.

Implemented 2 functions:
- *group*
- *endgroup*

Missing changes:
- Documentation - I could not find a suitable location for docs.
- Tests - I could not find a suitable location for tests.