### PR TITLE
Add support for the optional 'source' property to the error/warning functions

### DIFF
--- a/node/internal.ts
+++ b/node/internal.ts
@@ -20,6 +20,13 @@ import crypto = require('crypto');
 export var _knownVariableMap: { [key: string]: _KnownVariableInfo; } = {};
 
 export var _vault: vm.Vault;
+//-----------------------------------------------------
+// Enums
+//-----------------------------------------------------
+export enum IssueSource {
+    CustomerScript = 'CustomerScript',
+    TaskInternal = 'TaskInternal'
+}
 
 //-----------------------------------------------------
 // Validation Checks
@@ -282,11 +289,11 @@ export function _command(command: string, properties: any, message: string) {
     _writeLine(taskCmd.toString());
 }
 
-export function _warning(message: string, source?: string): void {
+export function _warning(message: string, source?: IssueSource): void {
     _command('task.issue', { 'type': 'warning', 'source': source }, message);
 }
 
-export function _error(message: string, source?: string): void {
+export function _error(message: string, source?: IssueSource): void {
     _command('task.issue', { 'type': 'error', 'source': source }, message);
 }
 

--- a/node/internal.ts
+++ b/node/internal.ts
@@ -282,17 +282,12 @@ export function _command(command: string, properties: any, message: string) {
     _writeLine(taskCmd.toString());
 }
 
-export function _warning(message: string): void {
-    _command('task.issue', { 'type': 'warning' }, message);
+export function _warning(message: string, source?: string): void {
+    _command('task.issue', { 'type': 'warning', 'source': source }, message);
 }
 
-export function _error(message: string, customerIssue: boolean = false): void {
-    let props = { 'type': 'error' };
-    if (customerIssue) {
-        props['customerissue'] = true;
-    }
-
-    _command('task.issue', props, message);
+export function _error(message: string, source?: string): void {
+    _command('task.issue', { 'type': 'error', 'source': source }, message);
 }
 
 export function _debug(message: string): void {

--- a/node/internal.ts
+++ b/node/internal.ts
@@ -286,10 +286,10 @@ export function _warning(message: string): void {
     _command('task.issue', { 'type': 'warning' }, message);
 }
 
-export function _error(message: string, userIssue: boolean = false): void {
+export function _error(message: string, customerIssue: boolean = false): void {
     let props = { 'type': 'error' };
-    if (userIssue) {
-        props['userissue'] = true;
+    if (customerIssue) {
+        props['customerissue'] = true;
     }
 
     _command('task.issue', props, message);

--- a/node/internal.ts
+++ b/node/internal.ts
@@ -286,8 +286,13 @@ export function _warning(message: string): void {
     _command('task.issue', { 'type': 'warning' }, message);
 }
 
-export function _error(message: string): void {
-    _command('task.issue', { 'type': 'error' }, message);
+export function _error(message: string, userIssue: boolean = false): void {
+    let props = { 'type': 'error' };
+    if (userIssue) {
+        props['userissue'] = true;
+    }
+
+    _command('task.issue', props, message);
 }
 
 export function _debug(message: string): void {

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",

--- a/node/task.ts
+++ b/node/task.ts
@@ -44,6 +44,8 @@ export enum FieldType {
     Url
 }
 
+export const IssueSource = im.IssueSource;
+
 /** Platforms supported by our build agent */
 export enum Platform {
     Windows,

--- a/powershell/VstsTaskSdk/LoggingCommandFunctions.ps1
+++ b/powershell/VstsTaskSdk/LoggingCommandFunctions.ps1
@@ -8,6 +8,11 @@ $script:loggingCommandEscapeMappings = @( # TODO: WHAT ABOUT "="? WHAT ABOUT "%"
 # TODO: BUG: Escape % ???
 # TODO: Add test to verify don't need to escape "=".
 
+$IssueSources = @{
+    CustomerScript = "CustomerScript"
+    TaskInternal = "TaskInternal"
+}
+
 <#
 .SYNOPSIS
 See https://github.com/Microsoft/vsts-tasks/blob/master/docs/authoring/commands.md
@@ -547,6 +552,8 @@ function Write-LogIssue {
         [string]$LineNumber,
         [string]$ColumnNumber,
         [switch]$AsOutput,
+        [AllowNull()]
+        [ValidateSet('CustomerScript', 'TaskInternal')]
         [string]$IssueSource)
 
     $command = Format-LoggingCommand -Area 'task' -Event 'logissue' -Data $Message -Properties @{

--- a/powershell/VstsTaskSdk/LoggingCommandFunctions.ps1
+++ b/powershell/VstsTaskSdk/LoggingCommandFunctions.ps1
@@ -287,7 +287,7 @@ function Write-TaskError {
         [string]$LineNumber,
         [string]$ColumnNumber,
         [switch]$AsOutput,
-        [bool]$CustomerIssue = $false)
+        [string]$IssueSource)
 
     Write-LogIssue -Type error @PSBoundParameters
 }
@@ -323,7 +323,8 @@ function Write-TaskWarning {
         [string]$SourcePath,
         [string]$LineNumber,
         [string]$ColumnNumber,
-        [switch]$AsOutput)
+        [switch]$AsOutput,
+        [string]$IssueSource)
 
     Write-LogIssue -Type warning @PSBoundParameters
 }
@@ -546,7 +547,7 @@ function Write-LogIssue {
         [string]$LineNumber,
         [string]$ColumnNumber,
         [switch]$AsOutput,
-        [bool]$CustomerIssue = $false)
+        [string]$IssueSource)
 
     $command = Format-LoggingCommand -Area 'task' -Event 'logissue' -Data $Message -Properties @{
             'type' = $Type
@@ -554,7 +555,7 @@ function Write-LogIssue {
             'sourcepath' = $SourcePath
             'linenumber' = $LineNumber
             'columnnumber' = $ColumnNumber
-            'customerissue' = $CustomerIssue
+            'source' = $IssueSource
         }
     if ($AsOutput) {
         return $command

--- a/powershell/VstsTaskSdk/LoggingCommandFunctions.ps1
+++ b/powershell/VstsTaskSdk/LoggingCommandFunctions.ps1
@@ -287,7 +287,7 @@ function Write-TaskError {
         [string]$LineNumber,
         [string]$ColumnNumber,
         [switch]$AsOutput,
-        [bool]$UserIssue = $false)
+        [bool]$CustomerIssue = $false)
 
     Write-LogIssue -Type error @PSBoundParameters
 }
@@ -546,7 +546,7 @@ function Write-LogIssue {
         [string]$LineNumber,
         [string]$ColumnNumber,
         [switch]$AsOutput,
-        [bool]$UserIssue = $false)
+        [bool]$CustomerIssue = $false)
 
     $command = Format-LoggingCommand -Area 'task' -Event 'logissue' -Data $Message -Properties @{
             'type' = $Type
@@ -554,7 +554,7 @@ function Write-LogIssue {
             'sourcepath' = $SourcePath
             'linenumber' = $LineNumber
             'columnnumber' = $ColumnNumber
-            'userissue' = $UserIssue
+            'customerissue' = $CustomerIssue
         }
     if ($AsOutput) {
         return $command

--- a/powershell/VstsTaskSdk/LoggingCommandFunctions.ps1
+++ b/powershell/VstsTaskSdk/LoggingCommandFunctions.ps1
@@ -286,7 +286,8 @@ function Write-TaskError {
         [string]$SourcePath,
         [string]$LineNumber,
         [string]$ColumnNumber,
-        [switch]$AsOutput)
+        [switch]$AsOutput,
+        [bool]$UserIssue = $false)
 
     Write-LogIssue -Type error @PSBoundParameters
 }
@@ -544,7 +545,8 @@ function Write-LogIssue {
         [string]$SourcePath,
         [string]$LineNumber,
         [string]$ColumnNumber,
-        [switch]$AsOutput)
+        [switch]$AsOutput,
+        [bool]$UserIssue = $false)
 
     $command = Format-LoggingCommand -Area 'task' -Event 'logissue' -Data $Message -Properties @{
             'type' = $Type
@@ -552,6 +554,7 @@ function Write-LogIssue {
             'sourcepath' = $SourcePath
             'linenumber' = $LineNumber
             'columnnumber' = $ColumnNumber
+            'userissue' = $UserIssue
         }
     if ($AsOutput) {
         return $command

--- a/powershell/VstsTaskSdk/VstsTaskSdk.psd1
+++ b/powershell/VstsTaskSdk/VstsTaskSdk.psd1
@@ -9,7 +9,7 @@
     PowerShellVersion = '3.0'
     FunctionsToExport = '*'
     CmdletsToExport = ''
-    VariablesToExport = ''
+    VariablesToExport = 'IssueSources'
     AliasesToExport = ''
     PrivateData = @{
         PSData = @{

--- a/powershell/VstsTaskSdk/VstsTaskSdk.psm1
+++ b/powershell/VstsTaskSdk/VstsTaskSdk.psm1
@@ -94,6 +94,10 @@ Export-ModuleMember -Function @(
         'Get-ClientCertificate'
     )
 
+Export-ModuleMember -Variable @(
+    'IssueSources'
+)
+
 # Override Out-Default globally.
 $null = New-Item -Force -Path "function:\global:Out-Default" -Value (Get-Command -CommandType Function -Name Out-Default -ListImported)
 New-Alias -Name Out-Default -Value "global:Out-Default" -Scope global

--- a/powershell/package-lock.json
+++ b/powershell/package-lock.json
@@ -1,5 +1,6 @@
 {
-  "version": "0.17.0",
+  "name": "powershell",
+  "version": "0.18.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/powershell/package.json
+++ b/powershell/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.17.0",
+  "version": "0.18.0",
   "private": true,
   "scripts": {
     "build": "node make.js build",


### PR DESCRIPTION
Added support for the optional 'source' property to the error/warning functions to distinguish internal task issues and the issues that occur because of incorrect customer actions (for example, the invalid user script).

Testing: local dev environment with additional changes in PowerShell, Bash and CmdLine tasks.

Changed the version of npm packages:
node 4.7.0 -> 4.8.0
powershell 0.17.0 -> 0.18.0