### PR TITLE
Add setSanitizedResult function

### DIFF
--- a/node/internal.ts
+++ b/node/internal.ts
@@ -49,6 +49,20 @@ export function _endsWith(str: string, end: string): boolean {
     return str.slice(-end.length) == end;
 }
 
+export function _truncateBeforeSensitiveKeyword(str: string, sensitiveKeywordsPattern: RegExp): string {
+    if(!str) {
+        return str;
+    }
+
+    const index = str.search(sensitiveKeywordsPattern); 
+
+    if (index <= 0) {
+        return str;
+    }
+
+    return `${str.substring(0, index)}...`;
+}
+
 //-----------------------------------------------------
 // General Helpers
 //-----------------------------------------------------

--- a/node/mock-task.ts
+++ b/node/mock-task.ts
@@ -31,6 +31,7 @@ module.exports.Platform = task.Platform;
 module.exports.setStdStream = task.setStdStream;
 module.exports.setErrStream = task.setErrStream;
 module.exports.setResult = task.setResult;
+module.exports.setSanitizedResult = task.setSanitizedResult;
 
 //-----------------------------------------------------
 // Loc Helpers

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "4.9.0",
+  "version": "4.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "4.9.0",
+  "version": "4.9.1",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",

--- a/node/task.ts
+++ b/node/task.ts
@@ -104,6 +104,24 @@ export function setResult(result: TaskResult, message: string, done?: boolean): 
     command('task.complete', properties, message);
 }
 
+/**
+ * Sets the result of the task with sanitized message.
+ *
+ * @param result    TaskResult enum of Succeeded, SucceededWithIssues, Failed, Cancelled or Skipped.
+ * @param message   A message which will be logged as an error issue if the result is Failed. Message will be truncated 
+ *                  before first occurence of wellknown sensitive keyword.
+ * @param done      Optional. Instructs the agent the task is done. This is helpful when child processes
+ *                  may still be running and prevent node from fully exiting. This argument is supported
+ *                  from agent version 2.142.0 or higher (otherwise will no-op).
+ * @returns         void
+ */
+
+export function setSanitizedResult(result: TaskResult, message: string, done?: boolean): void {
+    const pattern = /password|key|secret|bearer|authorization|token|pat/i;
+    const sanitizedMessage = im._truncateBeforeSensitiveKeyword(message, pattern);
+    setResult(result, sanitizedMessage, done);
+}
+
 //
 // Catching all exceptions
 //

--- a/node/test/internalhelpertests.ts
+++ b/node/test/internalhelpertests.ts
@@ -9,6 +9,33 @@ import * as tl from '../_build/task';
 import * as im from '../_build/internal';
 import * as mockery from '../_build/lib-mocker'
 
+describe('Internal String Helper Tests: _truncateBeforeSensitiveKeyword', function () {
+    
+    it('truncates before known sensitive keywords', () => {
+        const input = "this is a secret password";
+
+        const result = im._truncateBeforeSensitiveKeyword(input, /secret/i);
+
+        assert.strictEqual(result, "this is a ...");
+    });
+
+    it('does not truncate without sensitive keyword', () => {
+        const input = "this is a secret password";
+
+        const result = im._truncateBeforeSensitiveKeyword(input, /key/i);
+
+        assert.strictEqual(result, input);
+    });
+
+    it('process undefined gracefully', () => {
+        const input: string = undefined;
+
+        const result = im._truncateBeforeSensitiveKeyword(input, /key/i);
+
+        assert.strictEqual(result, input);
+    });
+});
+
 describe('Internal Path Helper Tests', function () {
 
     before(function (done) {

--- a/node/test/resulttests.ts
+++ b/node/test/resulttests.ts
@@ -108,4 +108,21 @@ describe('Result Tests', function () {
 
         done();
     })
+    it('setSanitizedResult success outputs', function (done) {
+        this.timeout(1000);
+
+        var stdStream = testutil.createStringStream();
+        tl.setStdStream(stdStream);
+        tl.setSanitizedResult(tl.TaskResult.Succeeded, 'success msg with secret data');
+
+        var expected = testutil.buildOutput(
+            ['##vso[task.debug]task result: Succeeded',
+                '##vso[task.complete result=Succeeded;]success msg with ...']);
+
+        var output = stdStream.getContents();
+
+        assert.equal(output, expected);
+
+        done();
+    })
 });


### PR DESCRIPTION
There were several cases when we observed sensitive data (such as passwords) leakage through `task.setResult` function. To prevent such behavior this PR introduces `setSanitizedResult` function that truncates the passed message before first occurrence of well known sensitive keyword. For more details see the original [incident](https://portal.microsofticm.com/imp/v3/incidents/incident/466877337/summary) or its [repair item](https://mseng.visualstudio.com/AzureDevOps/_workitems/edit/2147925).