### PR TITLE
Add audit action for task.issue

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 4.x
 
+### 4.11.0
+
+- Added audit action for task.issue [#1033](https://github.com/microsoft/azure-pipelines-task-lib/pull/1033)
+
 ### 4.10.0
 
 - Added `correlation ID` property for logging commands [#1021](https://github.com/microsoft/azure-pipelines-task-lib/pull/1021)

--- a/node/internal.ts
+++ b/node/internal.ts
@@ -30,6 +30,11 @@ export enum IssueSource {
     TaskInternal = 'TaskInternal'
 }
 
+export enum IssueAuditAction {
+    Unknown = 0,
+    ShellTasksValidation = 1,
+}
+
 //-----------------------------------------------------
 // Validation Checks
 //-----------------------------------------------------
@@ -52,11 +57,11 @@ export function _endsWith(str: string, end: string): boolean {
 }
 
 export function _truncateBeforeSensitiveKeyword(str: string, sensitiveKeywordsPattern: RegExp): string {
-    if(!str) {
+    if (!str) {
         return str;
     }
 
-    const index = str.search(sensitiveKeywordsPattern); 
+    const index = str.search(sensitiveKeywordsPattern);
 
     if (index <= 0) {
         return str;
@@ -250,7 +255,7 @@ export function _loc(key: string, ...param: any[]): string {
  * @param     name     name of the variable to get
  * @returns   string
  */
-export function _getVariable(name: string): string | undefined  {
+export function _getVariable(name: string): string | undefined {
     let varval: string | undefined;
 
     // get the metadata
@@ -305,12 +310,38 @@ export function _command(command: string, properties: any, message: string) {
     _writeLine(taskCmd.toString());
 }
 
-export function _warning(message: string, source: IssueSource = IssueSource.TaskInternal): void {
-    _command('task.issue', { 'type': 'warning', 'source': source, 'correlationId': _commandCorrelationId }, message);
+export function _warning(
+    message: string,
+    source: IssueSource = IssueSource.TaskInternal,
+    auditAction: IssueAuditAction = IssueAuditAction.Unknown
+): void {
+    _command(
+        'task.issue',
+        {
+            'type': 'warning',
+            'source': source,
+            'correlationId': _commandCorrelationId,
+            'auditAction': auditAction
+        },
+        message
+    );
 }
 
-export function _error(message: string, source: IssueSource = IssueSource.TaskInternal): void {
-    _command('task.issue', { 'type': 'error', 'source': source, 'correlationId': _commandCorrelationId }, message);
+export function _error(
+    message: string,
+    source: IssueSource = IssueSource.TaskInternal,
+    auditAction: IssueAuditAction = IssueAuditAction.Unknown
+): void {
+    _command(
+        'task.issue',
+        {
+            'type': 'error',
+            'source': source,
+            'correlationId': _commandCorrelationId,
+            'auditAction': auditAction
+        },
+        message
+    );
 }
 
 export function _debug(message: string): void {
@@ -801,7 +832,7 @@ export function _loadData(): void {
  * @param path  a path to a file.
  * @returns     true if path starts with double backslash, otherwise returns false.
  */
- export function _isUncPath(path: string) {
+export function _isUncPath(path: string) {
     return /^\\\\[^\\]/.test(path);
 }
 

--- a/node/internal.ts
+++ b/node/internal.ts
@@ -313,7 +313,7 @@ export function _command(command: string, properties: any, message: string) {
 export function _warning(
     message: string,
     source: IssueSource = IssueSource.TaskInternal,
-    auditAction: IssueAuditAction = IssueAuditAction.Unknown
+    auditAction?: IssueAuditAction
 ): void {
     _command(
         'task.issue',
@@ -330,7 +330,7 @@ export function _warning(
 export function _error(
     message: string,
     source: IssueSource = IssueSource.TaskInternal,
-    auditAction: IssueAuditAction = IssueAuditAction.Unknown
+    auditAction?: IssueAuditAction
 ): void {
     _command(
         'task.issue',

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "4.10.1",
+  "version": "4.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -654,7 +654,7 @@
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw=="
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "randombytes": {
       "version": "2.1.0",

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "4.10.1",
+  "version": "4.11.0",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",

--- a/powershell/Docs/ReleaseNotes.md
+++ b/powershell/Docs/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 0.21.0
+
+- Added audit action for task.issue [#1033](https://github.com/microsoft/azure-pipelines-task-lib/pull/1033)
+
 ## 0.17.0
 
 * Added `Invoke-VstsProcess` cmdlet (<https://github.com/microsoft/azure-pipelines-task-lib/pull/978>)

--- a/powershell/Tests/L0/Write-LoggingCommand.WritesAuditToIssues.ps1
+++ b/powershell/Tests/L0/Write-LoggingCommand.WritesAuditToIssues.ps1
@@ -1,0 +1,23 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\lib\Initialize-Test.ps1
+Invoke-VstsTaskScript -ScriptBlock {
+    $vstsModule = Get-Module -Name VstsTaskSdk
+
+    # 1
+    $actual = & $vstsModule Write-TaskError -Message "test error" -AsOutput
+    $expected = "##vso[task.logissue type=error;source=TaskInternal]test error"
+    Assert-TaskIssueMessagesAreEqual $expected $actual "No audit action in issue if not specified."
+
+    # 2
+    $actual = & $vstsModule Write-TaskWarning -Message "test warning" -AuditAction '1' -AsOutput
+    $expected = "##vso[task.logissue type=warning;source=TaskInternal;auditAction=1]test warning"
+    Assert-TaskIssueMessagesAreEqual $expected $actual "String audit action."
+
+    #3
+    $actual = & $vstsModule Write-TaskError -Message "test error" -AuditAction 1 -AsOutput
+    $expected = "##vso[task.logissue type=error;source=TaskInternal;auditAction=1]test error"
+    Assert-TaskIssueMessagesAreEqual $expected $actual "Int audit action."
+}

--- a/powershell/Tests/L0/Write-LoggingCommand.WritesTaskIssue.ps1
+++ b/powershell/Tests/L0/Write-LoggingCommand.WritesTaskIssue.ps1
@@ -8,21 +8,21 @@ Invoke-VstsTaskScript -ScriptBlock {
 
     # 1
     $actual = & $vstsModule Write-TaskError -Message "test error" -AsOutput
-    $expected = "##vso[task.logissue source=TaskInternal;type=error]test error"
+    $expected = "##vso[task.logissue type=error;source=TaskInternal]test error"
     Assert-TaskIssueMessagesAreEqual $expected $actual "The default 'TastInternal' source was added for errors."
 
     # 2
     $actual = & $vstsModule Write-TaskWarning -Message "test warning" -AsOutput
-    $expected = "##vso[task.logissue source=TaskInternal;type=warning]test warning"
+    $expected = "##vso[task.logissue type=warning;source=TaskInternal]test warning"
     Assert-TaskIssueMessagesAreEqual $expected $actual "The default 'TastInternal' source was added for warnings."
 
     #3
     $actual = & $vstsModule Write-TaskError -Message "test error" -IssueSource $IssueSources.CustomerScript -AsOutput
-    $expected = "##vso[task.logissue source=CustomerScript;type=error]test error"
+    $expected = "##vso[task.logissue type=error;source=CustomerScript]test error"
     Assert-TaskIssueMessagesAreEqual $expected $actual "Adds the specified issue source for errors."
 
     #4
     $actual = & $vstsModule Write-TaskWarning -Message "test warning" -IssueSource $IssueSources.CustomerScript -AsOutput
-    $expected = "##vso[task.logissue source=CustomerScript;type=warning]test warning"
+    $expected = "##vso[task.logissue type=warning;source=CustomerScript]test warning"
     Assert-TaskIssueMessagesAreEqual $expected $actual "Adds the specified issue source for warnings."
 }

--- a/powershell/Tests/L0/Write-LoggingCommand.WritesTaskIssueWithCorrelationId.ps1
+++ b/powershell/Tests/L0/Write-LoggingCommand.WritesTaskIssueWithCorrelationId.ps1
@@ -17,21 +17,21 @@ Invoke-VstsTaskScript -ScriptBlock {
 
     # 3
     $actual = & $vstsModule Write-TaskError -Message "test error" -AsOutput
-    $expected = "##vso[task.logissue correlationId=test_id123;source=TaskInternal;type=error]test error"
+    $expected = "##vso[task.logissue type=error;source=TaskInternal;correlationId=test_id123]test error"
     Assert-TaskIssueMessagesAreEqual $expected $actual "The default 'TastInternal' source and the correlation ID were added for errors."
 
     # 4
     $actual = & $vstsModule Write-TaskWarning -Message "test warning" -AsOutput
-    $expected = "##vso[task.logissue correlationId=test_id123;source=TaskInternal;type=warning]test warning"
+    $expected = "##vso[task.logissue type=warning;source=TaskInternal;correlationId=test_id123]test warning"
     Assert-TaskIssueMessagesAreEqual $expected $actual "The default 'TastInternal' source and the correlation ID were added for warnings."
 
     # 5
     $actual = & $vstsModule Write-TaskError -Message "test error" -IssueSource $IssueSources.CustomerScript -AsOutput
-    $expected = "##vso[task.logissue correlationId=test_id123;source=CustomerScript;type=error]test error"
+    $expected = "##vso[task.logissue type=error;source=CustomerScript;correlationId=test_id123]test error"
     Assert-TaskIssueMessagesAreEqual $expected $actual "Adds the specified issue source and the correlation ID for errors."
 
     # 6
     $actual = & $vstsModule Write-TaskWarning -Message "test warning" -IssueSource $IssueSources.CustomerScript -AsOutput
-    $expected = "##vso[task.logissue correlationId=test_id123;source=CustomerScript;type=warning]test warning"
+    $expected = "##vso[task.logissue type=warning;source=CustomerScript;correlationId=test_id123]test warning"
     Assert-TaskIssueMessagesAreEqual $expected $actual "Adds the specified issue source and the correlation ID for warnings."
 }

--- a/powershell/Tests/lib/TestHelpersModule/PublicFunctions.ps1
+++ b/powershell/Tests/lib/TestHelpersModule/PublicFunctions.ps1
@@ -22,6 +22,7 @@ function Assert-TaskIssueMessagesAreEqual {
     [CmdletBinding()]
     param([string]$Expected, [string]$Actual, [string]$Message)
 
+    Write-Verbose "Asserting Task issue messages are equal. Expected: '$Expected' ; Actual: '$Actual'."
     if ($Expected -ne $Actual) {
         throw ("Assert are equal failed. Expected: '$Expected' ; Actual: '$Actual'. $Message".Trim())
     }

--- a/powershell/VstsTaskSdk/LoggingCommandFunctions.ps1
+++ b/powershell/VstsTaskSdk/LoggingCommandFunctions.ps1
@@ -19,6 +19,11 @@ $IssueSources = @{
     TaskInternal = "TaskInternal"
 }
 
+$IssueAuditActions = @{
+    Unknown = 0
+    ShellTasksValidation = 1
+}
+
 <#
 .SYNOPSIS
 See https://github.com/Microsoft/vsts-tasks/blob/master/docs/authoring/commands.md
@@ -298,7 +303,9 @@ function Write-TaskError {
         [string]$LineNumber,
         [string]$ColumnNumber,
         [switch]$AsOutput,
-        [string]$IssueSource)
+        [string]$IssueSource,
+        [int]$AuditAction
+    )
 
     Write-LogIssue -Type error @PSBoundParameters
 }
@@ -335,7 +342,9 @@ function Write-TaskWarning {
         [string]$LineNumber,
         [string]$ColumnNumber,
         [switch]$AsOutput,
-        [string]$IssueSource)
+        [string]$IssueSource,
+        [int]$AuditAction
+    )
 
     Write-LogIssue -Type warning @PSBoundParameters
 }
@@ -560,7 +569,10 @@ function Write-LogIssue {
         [switch]$AsOutput,
         [AllowNull()]
         [ValidateSet('CustomerScript', 'TaskInternal')]
-        [string]$IssueSource = $IssueSources.TaskInternal)
+        [string]$IssueSource = $IssueSources.TaskInternal,
+        [AllowNull()]
+        [int]$AuditAction = $IssueAuditActions.Unknown
+    )
 
     $command = Format-LoggingCommand -Area 'task' -Event 'logissue' -Data $Message -Properties @{
             'type' = $Type
@@ -570,6 +582,7 @@ function Write-LogIssue {
             'columnnumber' = $ColumnNumber
             'source' = $IssueSource
             'correlationId' = $commandCorrelationId
+            'auditAction' = $AuditAction
         }
     if ($AsOutput) {
         return $command

--- a/powershell/VstsTaskSdk/LoggingCommandFunctions.ps1
+++ b/powershell/VstsTaskSdk/LoggingCommandFunctions.ps1
@@ -19,11 +19,6 @@ $IssueSources = @{
     TaskInternal = "TaskInternal"
 }
 
-$IssueAuditActions = @{
-    Unknown = 0
-    ShellTasksValidation = 1
-}
-
 <#
 .SYNOPSIS
 See https://github.com/Microsoft/vsts-tasks/blob/master/docs/authoring/commands.md
@@ -304,7 +299,7 @@ function Write-TaskError {
         [string]$ColumnNumber,
         [switch]$AsOutput,
         [string]$IssueSource,
-        [int]$AuditAction
+        [string]$AuditAction
     )
 
     Write-LogIssue -Type error @PSBoundParameters
@@ -343,7 +338,7 @@ function Write-TaskWarning {
         [string]$ColumnNumber,
         [switch]$AsOutput,
         [string]$IssueSource,
-        [int]$AuditAction
+        [string]$AuditAction
     )
 
     Write-LogIssue -Type warning @PSBoundParameters
@@ -570,8 +565,7 @@ function Write-LogIssue {
         [AllowNull()]
         [ValidateSet('CustomerScript', 'TaskInternal')]
         [string]$IssueSource = $IssueSources.TaskInternal,
-        [AllowNull()]
-        [int]$AuditAction = $IssueAuditActions.Unknown
+        [string]$AuditAction
     )
 
     $command = Format-LoggingCommand -Area 'task' -Event 'logissue' -Data $Message -Properties @{

--- a/powershell/VstsTaskSdk/LoggingCommandFunctions.ps1
+++ b/powershell/VstsTaskSdk/LoggingCommandFunctions.ps1
@@ -521,7 +521,7 @@ function Format-LoggingCommand {
         [Parameter(Mandatory = $true)]
         [string]$Event,
         [string]$Data,
-        [hashtable]$Properties)
+        [System.Collections.IDictionary]$Properties)
 
     # Append the preamble.
     [System.Text.StringBuilder]$sb = New-Object -TypeName System.Text.StringBuilder
@@ -568,16 +568,17 @@ function Write-LogIssue {
         [string]$AuditAction
     )
 
-    $command = Format-LoggingCommand -Area 'task' -Event 'logissue' -Data $Message -Properties @{
-            'type' = $Type
-            'code' = $ErrCode
-            'sourcepath' = $SourcePath
-            'linenumber' = $LineNumber
-            'columnnumber' = $ColumnNumber
-            'source' = $IssueSource
-            'correlationId' = $commandCorrelationId
-            'auditAction' = $AuditAction
-        }
+    $properties = [ordered]@{
+        'type'          = $Type
+        'code'          = $ErrCode
+        'sourcepath'    = $SourcePath
+        'linenumber'    = $LineNumber
+        'columnnumber'  = $ColumnNumber
+        'source'        = $IssueSource
+        'correlationId' = $commandCorrelationId
+        'auditAction'   = $AuditAction
+    }
+    $command = Format-LoggingCommand -Area 'task' -Event 'logissue' -Data $Message -Properties $properties
     if ($AsOutput) {
         return $command
     }

--- a/powershell/VstsTaskSdk/VstsTaskSdk.psm1
+++ b/powershell/VstsTaskSdk/VstsTaskSdk.psm1
@@ -95,9 +95,14 @@ Export-ModuleMember -Function @(
         'Get-ClientCertificate'
     )
 
+$IssueAuditActions = @{
+    Unknown              = '0'
+    ShellTasksValidation = '1'
+}
+
 Export-ModuleMember -Variable @(
     'IssueSources'
-    'IssueAuditActions'
+    $IssueAuditActions
 )
 
 # Override Out-Default globally.

--- a/powershell/VstsTaskSdk/VstsTaskSdk.psm1
+++ b/powershell/VstsTaskSdk/VstsTaskSdk.psm1
@@ -97,6 +97,7 @@ Export-ModuleMember -Function @(
 
 Export-ModuleMember -Variable @(
     'IssueSources'
+    'IssueAuditActions'
 )
 
 # Override Out-Default globally.

--- a/powershell/package-lock.json
+++ b/powershell/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.20.1",
+  "version": "0.21.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/powershell/package.json
+++ b/powershell/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.20.1",
+  "version": "0.21.0",
   "private": true,
   "scripts": {
     "build": "node make.js build",


### PR DESCRIPTION
Added audit action data property for issues.
Also, fixed order of properties for `task.issue` log command

WI: [AB#2123720](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2123720)