### PR TITLE
Removed multiline check for setting secret

### DIFF
--- a/node/task.ts
+++ b/node/task.ts
@@ -214,10 +214,6 @@ export function setVariable(name: string, val: string, secret: boolean = false, 
     let varValue = val || '';
     debug('set ' + name + '=' + (secret && varValue ? '********' : varValue));
     if (secret) {
-        if (varValue && varValue.match(/\r|\n/) && `${process.env['SYSTEM_UNSAFEALLOWMULTILINESECRET']}`.toUpperCase() != 'TRUE') {
-            throw new Error(loc('LIB_MultilineSecret'));
-        }
-
         im._vault.storeSecret('SECRET_' + key, varValue);
         delete process.env[key];
     } else {
@@ -238,9 +234,6 @@ export function setVariable(name: string, val: string, secret: boolean = false, 
  */
 export function setSecret(val: string): void {
     if (val) {
-        if (val.match(/\r|\n/) && `${process.env['SYSTEM_UNSAFEALLOWMULTILINESECRET']}`.toUpperCase() !== 'TRUE') {
-            throw new Error(loc('LIB_MultilineSecret'));
-        }
         command('task.setsecret', {}, val);
     }
 }


### PR DESCRIPTION
Issue #20049 in azure-pipelines-tasks which causes multiline secrets to fail the npm authenticate version 0.241.1 task