### PR TITLE
Corrected node tool exit event debug log

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 4.x
 
+## 4.17.1
+
+- Corrected node tool exit event debug log - [#1063](https://github.com/microsoft/azure-pipelines-task-lib/pull/1063)
+
 ## 4.17.0
 
 - Added signal handler for process execution to kill process with proper signal - [#1008](https://github.com/microsoft/azure-pipelines-task-lib/pull/1008)

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "4.17.0",
+  "version": "4.17.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "4.17.0",
+  "version": "4.17.1",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",

--- a/node/toolrunner.ts
+++ b/node/toolrunner.ts
@@ -1185,7 +1185,7 @@ export class ToolRunner extends events.EventEmitter {
         cp.on('exit', (code: number, signal: number | NodeJS.Signals) => {
             state.processExitCode = code;
             state.processExited = true;
-            this._debug(`STDIO streams have closed and received exit code ${code} and signal ${signal} for tool '${this.toolPath}'`);
+            this._debug(`STDIO streams have exited and received exit code ${code} and signal ${signal} for tool '${this.toolPath}'`);
             state.CheckComplete()
         });
 
@@ -1317,7 +1317,7 @@ export class ToolRunner extends events.EventEmitter {
         cp.on('exit', (code: number, signal: number | NodeJS.Signals) => {
             state.processExitCode = code;
             state.processExited = true;
-            this._debug(`STDIO streams have closed and received exit code ${code} and signal ${signal} for tool '${this.toolPath}'`);
+            this._debug(`STDIO streams have exited and received exit code ${code} and signal ${signal} for tool '${this.toolPath}'`);
             state.CheckComplete()
         });
 


### PR DESCRIPTION
Updated the 'exit' event debug log to distinguish it from the 'close' event