### PR TITLE
Fix for checks not failing on compilation error

### DIFF
--- a/node/make.js
+++ b/node/make.js
@@ -21,7 +21,6 @@ target.build = function() {
     target.loc();
 
     run('npx tsc -v');
-
     run('npx tsc --outDir ' + buildPath);
     cp(rp('package.json'), buildPath);
     cp(rp('package-lock.json'), buildPath);
@@ -67,9 +66,11 @@ target.loc = function() {
 process.on('uncaughtException', err => {
     console.error(`Uncaught exception: ${err.message}`);
     console.debug(err.stack);
+    exit(1);
 });
 
 process.on('unhandledRejection', err => {
     console.error(`Unhandled rejection: ${err.message}`);
     console.debug(err.stack);
+    exit(1);
 });

--- a/node/make.js
+++ b/node/make.js
@@ -11,12 +11,6 @@ var rp = function (relPath) {
 var buildPath = path.join(__dirname, '_build');
 var testPath = path.join(__dirname, '_test');
 
-if (process.env['TF_BUILD']) {
-    // the CI controls the version of node, so it runs using "node make.js test" instead of "npm test"
-    // update the PATH when running during CI
-    buildutils.addPath(path.join(__dirname, 'node_modules', '.bin'));
-}
-
 target.clean = function () {
     rm('-Rf', buildPath);
     rm('-Rf', testPath);
@@ -26,9 +20,9 @@ target.build = function() {
     target.clean();
     target.loc();
 
-    run('tsc -v');
+    run('npm tsc -v');
 
-    run('tsc --outDir ' + buildPath);
+    run('npm tsc --outDir ' + buildPath);
     cp(rp('package.json'), buildPath);
     cp(rp('package-lock.json'), buildPath);
     cp(rp('README.md'), buildPath);

--- a/node/make.js
+++ b/node/make.js
@@ -20,9 +20,9 @@ target.build = function() {
     target.clean();
     target.loc();
 
-    run('npm tsc -v');
+    run('npx tsc -v');
 
-    run('npm tsc --outDir ' + buildPath);
+    run('npx tsc --outDir ' + buildPath);
     cp(rp('package.json'), buildPath);
     cp(rp('package-lock.json'), buildPath);
     cp(rp('README.md'), buildPath);

--- a/node/make.js
+++ b/node/make.js
@@ -26,6 +26,8 @@ target.build = function() {
     target.clean();
     target.loc();
 
+    run('tsc -v');
+
     run('tsc --outDir ' + buildPath);
     cp(rp('package.json'), buildPath);
     cp(rp('package-lock.json'), buildPath);

--- a/node/task.ts
+++ b/node/task.ts
@@ -9,7 +9,7 @@ import im = require('./internal');
 import tcm = require('./taskcommand');
 import trm = require('./toolrunner');
 import semver = require('semver');
-fdsfdssf
+
 export enum TaskResult {
     Succeeded = 0,
     SucceededWithIssues = 1,

--- a/node/task.ts
+++ b/node/task.ts
@@ -9,7 +9,7 @@ import im = require('./internal');
 import tcm = require('./taskcommand');
 import trm = require('./toolrunner');
 import semver = require('semver');
-
+fdsfdssf
 export enum TaskResult {
     Succeeded = 0,
     SucceededWithIssues = 1,


### PR DESCRIPTION
For local builds, use tsc from modules (via npx)