### PR TITLE
Remove duplicate debug logs when using `task.exec*` wrappers

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 4.x
 
+## 4.17.3
+
+- Remove duplicate debug logs when using task.exec* wrappers - [#1071](https://github.com/microsoft/azure-pipelines-task-lib/pull/1071)
+
 ## 4.17.2
 
 - Fix ToolRunner stdline/errline events buffering - [#1055](https://github.com/microsoft/azure-pipelines-task-lib/pull/1055)

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "4.17.2",
+  "version": "4.17.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "4.17.2",
+  "version": "4.17.3",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",

--- a/node/task.ts
+++ b/node/task.ts
@@ -1512,10 +1512,6 @@ export function rmRF(inputPath: string): void {
  */
 export function execAsync(tool: string, args: any, options?: trm.IExecOptions): Promise<number> {
     let tr: trm.ToolRunner = this.tool(tool);
-    tr.on('debug', (data: string) => {
-        debug(data);
-    });
-
     if (args) {
         if (args instanceof Array) {
             tr.arg(args);
@@ -1540,10 +1536,6 @@ export function execAsync(tool: string, args: any, options?: trm.IExecOptions): 
  */
 export function exec(tool: string, args: any, options?: trm.IExecOptions): Q.Promise<number> {
     let tr: trm.ToolRunner = this.tool(tool);
-    tr.on('debug', (data: string) => {
-        debug(data);
-    });
-
     if (args) {
         if (args instanceof Array) {
             tr.arg(args);
@@ -1568,10 +1560,6 @@ export function exec(tool: string, args: any, options?: trm.IExecOptions): Q.Pro
  */
 export function execSync(tool: string, args: string | string[], options?: trm.IExecSyncOptions): trm.IExecSyncResult {
     let tr: trm.ToolRunner = this.tool(tool);
-    tr.on('debug', (data: string) => {
-        debug(data);
-    });
-
     if (args) {
         if (args instanceof Array) {
             tr.arg(args);


### PR DESCRIPTION
Issue #1069

We already subscribe to debug events in the [tool function](https://github.com/microsoft/azure-pipelines-task-lib/blob/89c945c168e9bee843b3d87a528f2cf2beced0ef/node/task.ts#L1593-L1600)

So no need to do this twice as it leads to debug logs duplication.

Before:
```txt
##vso[task.debug]exec tool: C:\windows\System32\WindowsPowerShell\v1.0\powershell.exe
##vso[task.debug]exec tool: C:\windows\System32\WindowsPowerShell\v1.0\powershell.exe
##vso[task.debug]arguments:
##vso[task.debug]arguments:
##vso[task.debug]   -c
##vso[task.debug]   -c
##vso[task.debug]   echo hello
##vso[task.debug]   echo hello
[command]C:\windows\System32\WindowsPowerShell\v1.0\powershell.exe -c "echo hello"
hello
##vso[task.debug]Process exited with code 0 and signal null for tool 'C:\windows\System32\WindowsPowerShell\v1.0\powershell.exe'
##vso[task.debug]Process exited with code 0 and signal null for tool 'C:\windows\System32\WindowsPowerShell\v1.0\powershell.exe'
```


after:
```txt
##vso[task.debug]exec tool: C:\windows\System32\WindowsPowerShell\v1.0\powershell.exe
##vso[task.debug]arguments:
##vso[task.debug]   -c
##vso[task.debug]   echo hello
[command]C:\windows\System32\WindowsPowerShell\v1.0\powershell.exe -c "echo hello"
hello
##vso[task.debug]Process exited with code 0 and signal null for tool 'C:\windows\System32\WindowsPowerShell\v1.0\powershell.exe'
```

