### PR TITLE
Fix process invocation for PowerShell handler

### DIFF
--- a/powershell/VstsTaskSdk/ToolFunctions.ps1
+++ b/powershell/VstsTaskSdk/ToolFunctions.ps1
@@ -202,13 +202,8 @@ function Invoke-Process {
             $processOptions.Add("RedirectStandardError", $StdErrPath)
         }
 
-        # TODO: For some reason, -Wait is not working on agent.
-        # Agent starts executing the System usage metrics and hangs the step forever.
-        $proc = Start-Process @processOptions
-
-        # https://stackoverflow.com/a/23797762
-        $null = $($proc.Handle)
-        $proc.WaitForExit()
+        # We can't use -Wait in this case as it waits for the whole process tree, it can lead to unexprected hangs
+        $proc = Start-Process @processOptions | Wait-Process
 
         $procExitCode = $proc.ExitCode
         Write-Verbose "Exit code: $procExitCode"

--- a/powershell/VstsTaskSdk/ToolFunctions.ps1
+++ b/powershell/VstsTaskSdk/ToolFunctions.ps1
@@ -203,7 +203,8 @@ function Invoke-Process {
         }
 
         # We can't use -Wait in this case as it waits for the whole process tree, it can lead to unexprected hangs
-        $proc = Start-Process @processOptions | Wait-Process
+        $proc = Start-Process @processOptions
+        Wait-Process -InputObject $proc
 
         $procExitCode = $proc.ExitCode
         Write-Verbose "Exit code: $procExitCode"

--- a/powershell/package-lock.json
+++ b/powershell/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-task-sdk",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -408,9 +408,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha1-CVl5+bzA0J2jJNWNA86Pg3TL5lo=",
+      "version": "4.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typescript/-/typescript-4.0.2.tgz",
+      "integrity": "sha1-fqfIh3fHI8aB4zv3mIvl0AjQWsI=",
       "dev": true
     },
     "utf8-byte-length": {

--- a/powershell/package.json
+++ b/powershell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-task-sdk",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "private": true,
   "scripts": {
     "build": "node make.js build",

--- a/powershell/package.json
+++ b/powershell/package.json
@@ -16,6 +16,6 @@
     "mocha": "5.2.0",
     "nodejs-file-downloader": "^4.11.1",
     "shelljs": "^0.8.5",
-    "typescript": "^4.0.2"
+    "typescript": "4.0.2"
   }
 }


### PR DESCRIPTION
Recently we faced [the issue](https://github.com/microsoft/azure-pipelines-tasks/issues/19781) where exit code for process was not set, and it was the root cause of pipeline failures.

I noticed that PowerShell could behave incorrectly if we manage the process using .NET API directly (for instance, we had to cache the process handle to obtain the status code as a workaround. please check https://stackoverflow.com/a/23797762)

Even though I didn't manage to reproduce the issue specified at the beginning by myself. I suppose that native PS cmdlets will help to fix it. 

WI: [AB#2222447](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2222447)

Testing: manual, unit tests

Other changes: Changed ts version to fix the unit tests