### PR TITLE
Fix - [CodeQL:Warning]: SM03609: Unsafe shell command constructed from library input (in node/task.ts)- AB#2236216

### DIFF
--- a/node/task.ts
+++ b/node/task.ts
@@ -1435,11 +1435,11 @@ export function rmRF(inputPath: string): void {
         try {
             if (fs.statSync(inputPath).isDirectory()) {
                 debug('removing directory ' + inputPath);
-                childProcess.execSync(`rd /s /q "${inputPath}"`);
+                childProcess.execFileSync("cmd.exe", ["/c", "rd", "/s", "/q", inputPath]);
             }
             else {
                 debug('removing file ' + inputPath);
-                childProcess.execSync(`del /f /a "${inputPath}"`);
+                childProcess.execFileSync("cmd.exe", ["/c", "del", "/f", "/a", inputPath]);
             }
         }
         catch (err) {


### PR DESCRIPTION
## What is the change?

Fixes the CodeQL vulnerability - Unsafe shell command constructed from library input (in node/task.ts)

## Description

**Original Code:** The original code constructs a shell command by concatenating the inputPath variable directly into the command string. This can be exploited if the inputPath contains special characters or malicious input.

```childProcess.execSync(`rd /s /q "${inputPath}"`);```
```childProcess.execSync(`del /f /a "${inputPath}"`);```

**Fixed Code:** The fixed code uses childProcess.execFileSync to pass the command and its arguments separately, which prevents the shell from interpreting the input.

```childProcess.execFileSync("cmd.exe", ["/c", "rd", "/s", "/q", inputPath]);```
```childProcess.execFileSync("cmd.exe", ["/c", "del", "/f", "/a", inputPath]);```

This approach ensures that any special characters in the inputPath are properly handled, preventing command injection attacks.

## Functional Validation

1. Create a local TypeScript project.
2. Write a test script that calls the `rmRF` function with different input paths.

> Note: Here is the link to the test setup - 
[typescript-project.zip](https://github.com/user-attachments/files/18090919/typescript-project.zip)

### Test 1: Sanity Functional Test

Create a few files and directories and attempt to delete them with the revised implementation. See the attached test project.

![image](https://github.com/user-attachments/assets/d876f3f0-de0c-4bfa-9c8c-b74ec02f79af)

### Test 2: Command Injection Test

Original code is vulnerable to Command Injection. Here is the sample snippet with which this was established.
```
inputPath = 'C:\\Users\\adityamankal\\Workspace\\typescript-project\\testDir\\testFile.txt" && echo %USERPROFILE% > C:\\Users\\adityamankal\\Workspace\\env_output.txt && "';

childProcess.execSync(`del /f /q "${inputPath}"`);
```
The above script deletes the `testFile.txt` but it also dumps the `USERPROFILE` variable to `env_output.txt`


Revised code is no longer vulnerable to Command Injection. Here is the sample snippet with which this was verified.
```
const inputPath = 'C:\\Users\\adityamankal\\Workspace\\typescript-project\\testDir\\testFile.txt" && echo %USERPROFILE% > C:\\Users\\adityamankal\\Workspace\\env_output.txt && "';

childProcess.execFileSync("cmd.exe", ["/c", "del", "/f", "/a", inputPath]);
```

## Related Documents

[[SM03609] Unsafe shell command constructed from library input](https://liquid.microsoft.com/Web/Object/Read/ScanningToolWarnings/Requirements/CodeQL.SM03609#Zguide)