### PR TITLE
Suppressing CODEQL warning

### DIFF
--- a/node/internal.ts
+++ b/node/internal.ts
@@ -1059,7 +1059,7 @@ function _exposeTaskLibSecret(keyFile: string, secret: string): string | undefin
     if (secret) {
         let encryptKey = crypto.randomBytes(256);
         let cipher = crypto.createCipher("aes-256-ctr", encryptKey);
-        let encryptedContent = cipher.update(secret, "utf8", "hex");
+        let encryptedContent = cipher.update(secret, "utf8", "hex");  // CodeQL [SM01511] agent need to retrieve password later to connect to proxy server
         encryptedContent += cipher.final("hex");
 
         let storageFile = path.join(_getVariable('Agent.TempDirectory') || _getVariable("agent.workFolder") || process.cwd(), keyFile);


### PR DESCRIPTION
The suppression is needed as this is genuine scenario based on [OWASP](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#hashing-vs-encryption). This is approved by internal security team as well. 