### PR TITLE
Fix issue with missing slash in path

### DIFF
--- a/node/mock-test.ts
+++ b/node/mock-test.ts
@@ -262,7 +262,7 @@ export class MockTestRunner {
         }
 
         // Write marker to indicate download completed.
-        const marker = downloadDestination + '.completed';
+        const marker = path.join(downloadDestination, '.completed');
         fs.writeFileSync(marker, '');
         return downloadPath
     }


### PR DESCRIPTION
The current implementation leads to a path like `_downloads/node20.completed` instead of `_downloads/node20/.completed`.

I've changed this to match the way the node.exe filename is joined to the `downloadDestination` path.