### PR TITLE
Fix: Symlink Resolution for Cross-Platform Copy Operations

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",

--- a/node/task.ts
+++ b/node/task.ts
@@ -1188,7 +1188,8 @@ export function cp(sourceOrOptions: unknown, destinationOrSource: string, option
 
         try {
             if (lstatSource.isSymbolicLink()) {
-                source = fs.readlinkSync(source);
+                const symlinkTarget = fs.readlinkSync(source);
+                source = path.resolve(path.dirname(source), symlinkTarget);
                 lstatSource = fs.lstatSync(source);
             }
             if (lstatSource.isFile()) {

--- a/node/task.ts
+++ b/node/task.ts
@@ -1227,7 +1227,8 @@ const copyDirectoryWithResolvedSymlinks = (src: string, dest: string, force: boo
 
         if (entry.isSymbolicLink()) {
             // Resolve the symbolic link and copy the target
-            const resolvedPath = fs.readlinkSync(srcPath);
+            const symlinkTarget = fs.readlinkSync(srcPath);
+            const resolvedPath = path.resolve(path.dirname(srcPath), symlinkTarget);
             const stat = fs.lstatSync(resolvedPath);
 
             if (stat.isFile()) {

--- a/node/test/cp.ts
+++ b/node/test/cp.ts
@@ -161,4 +161,20 @@ describe('cp cases', () => {
 
     done();
   });
+
+  it('copy symlink pointing to file where symlink is create using relative path to target file', (done) => {
+    const rootSymlinkName = 'root-symlink-to-temp2-file';
+    const symlinkPath = path.join(DIRNAME, rootSymlinkName);
+    const targetPath = path.relative(DIRNAME, TEMP_DIR_2_FILE_1);
+
+    fs.symlinkSync(targetPath, symlinkPath, 'file');
+    
+    const destPath = path.join(TEST_DEST_DIR, rootSymlinkName);
+    tl.cp(symlinkPath, destPath);
+    assert(fs.existsSync(destPath), 'Destination file was not created');
+    assert(!fs.lstatSync(destPath).isSymbolicLink(), 'Destination should not be a symlink');
+    assert.equal(fs.readFileSync(destPath, 'utf8'), 'file1', 'File content does not match source');
+
+    done();
+  });
 });

--- a/node/test/cp.ts
+++ b/node/test/cp.ts
@@ -162,13 +162,13 @@ describe('cp cases', () => {
     done();
   });
 
-  it('copy symlink pointing to file where symlink is create using relative path to target file', (done) => {
+  it('copy symlink pointing to file where symlink is created using relative path to target file', (done) => {
     const rootSymlinkName = 'root-symlink-to-temp2-file';
     const symlinkPath = path.join(DIRNAME, rootSymlinkName);
     const targetPath = path.relative(DIRNAME, TEMP_DIR_2_FILE_1);
 
     fs.symlinkSync(targetPath, symlinkPath, 'file');
-    
+
     const destPath = path.join(TEST_DEST_DIR, rootSymlinkName);
     tl.cp(symlinkPath, destPath);
     assert(fs.existsSync(destPath), 'Destination file was not created');


### PR DESCRIPTION
**Problem Being Solved:**
- The original code failed on Ubuntu when handling relative symbolic links
- Windows typically uses absolute paths in symlinks, while Linux often uses relative paths
- When copying files with relative symlinks, the code would fail with ENOENT (file not found) errors

**Why Original Code Failed:**
`source = fs.readlinkSync(source);`
- This simply reads the raw symlink target path
- On Linux with relative symlinks (e.g., ../file.txt), this raw path would be used directly
- The relative path would be evaluated from the wrong working directory context

**How New Code Fixes It:**
- Gets the directory containing the symlink using `path.dirname(source)`
- Uses `path.resolve()` to convert relative paths to absolute paths
- Resolves the symlink target relative to its containing directory
