### PR TITLE
Replace Array.flat() with custom flattenArray() function for Node.js compatibility

### DIFF
--- a/node/task.ts
+++ b/node/task.ts
@@ -1047,7 +1047,7 @@ export function ls(optionsOrPaths?: unknown, ...paths: unknown[]): string[] {
 
     // Flatten paths if the paths argument is array
     if (Array.isArray(paths)) {
-        paths = paths.flat(Infinity);
+        paths = flattenArray(paths);
     }
 
     // If the first argument is not options, then it is a path
@@ -1119,6 +1119,12 @@ export function ls(optionsOrPaths?: unknown, ...paths: unknown[]): string[] {
             throw new Error(loc('LIB_OperationFailed', 'ls', error));
         }
     }
+}
+
+function flattenArray(arr: any[]): any[] {
+    return arr.reduce((flat, toFlatten) => {
+        return flat.concat(Array.isArray(toFlatten) ? flattenArray(toFlatten) : toFlatten);
+    }, []);
 }
 
 type CopyOptionsVariants = OptionsPermutations<'frn'>;


### PR DESCRIPTION
**Problem**
The current code uses Array.flat() which is only available in Node.js versions >= 12. This causes compatibility issues when running on older Node.js versions that are still supported by Azure Pipelines agents.

**Changes**

- Added new flattenArray() helper function to recursively flatten nested arrays
- Removed usage of Array.flat() method

**Github Issue Link:** https://github.com/microsoft/azure-pipelines-tasks/issues/21048

**Testing**
Tested with already existing unit tests having multiple paths as input to LS function in an array. 
