### PR TITLE
LS function fix for single file input

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",

--- a/node/task.ts
+++ b/node/task.ts
@@ -1095,7 +1095,6 @@ export function ls(optionsOrPaths?: unknown, ...paths: unknown[]): string[] {
             }
         }
         paths.push(...remainingPaths);
-
         while (paths.length > 0) {
             const pathEntry = resolve(paths.shift());
             if (pathEntry?.includes('*')) {

--- a/node/task.ts
+++ b/node/task.ts
@@ -1036,6 +1036,7 @@ export function ls(...paths: string[]): string[];
  * @return {string[]}                  - An array of files in the given path(s).
  */
 export function ls(optionsOrPaths?: unknown, ...paths: unknown[]): string[] {
+    console.log('[ls] called with:', { optionsOrPaths, paths });
     let isRecursive = false;
     let includeHidden = false;
 
@@ -1043,11 +1044,14 @@ export function ls(optionsOrPaths?: unknown, ...paths: unknown[]): string[] {
         const options = String(optionsOrPaths).toLowerCase();
         isRecursive = options.includes('r');
         includeHidden = options.includes('a');
+        console.log('[ls] parsed options:', { isRecursive, includeHidden });
     }
 
     // Flatten paths if the paths argument is array
     if (Array.isArray(paths)) {
-        paths = paths.flat(Infinity);
+        // paths = paths.flat(Infinity);
+        paths = flattenArray(paths);
+        console.log('[ls] flattened paths:', paths);
     }
 
     // If the first argument is not options, then it is a path
@@ -1065,24 +1069,66 @@ export function ls(optionsOrPaths?: unknown, ...paths: unknown[]): string[] {
         } else {
             paths.push(...pathsFromOptions);
         }
+        console.log('[ls] paths after optionsOrPaths handling:', paths);
     }
 
     if (paths.length === 0) {
         paths.push(path.resolve('.'));
+        console.log('[ls] no paths provided, using current directory:', paths);
     }
     const pathsCopy = [...paths];
     const preparedPaths: string[] = [];
+    const results: string[] = [];
+
     try {
+        let remainingPaths: string[] = [];
         while (paths.length > 0) {
             const pathEntry = resolve(paths.shift());
+            console.log('[ls] processing pathEntry:', pathEntry);
+
             if (pathEntry?.includes('*')) {
+                // Keep wildcards for later processing
+                remainingPaths.push(pathEntry);
+                continue;
+            }
+
+            try {
+                const stats = fs.lstatSync(pathEntry);
+                if (stats.isFile()) {
+                    // For files, just add the basename to results
+                    const fileName = path.basename(pathEntry);
+                    console.log('[ls] adding direct file:', fileName);
+                    results.push(fileName);
+                } else {
+                    // Keep directories for later processing
+                    remainingPaths.push(pathEntry);
+                }
+            } catch (err) {
+                if (err.code === 'ENOENT') {
+                    throw new Error(loc('LIB_PathNotFound', 'ls', err.message));
+                }
+                throw err;
+            }
+        }
+        paths.push(...remainingPaths);
+        while (paths.length > 0) {
+            const pathEntry = resolve(paths.shift());
+            console.log('[ls] processing pathEntry:', pathEntry);
+            if (pathEntry?.includes('*')) {
+                const matches = findMatch(path.dirname(pathEntry), [path.basename(pathEntry)]);
+                console.log('[ls] wildcard match:', matches);
                 paths.push(...findMatch(path.dirname(pathEntry), [path.basename(pathEntry)]));
+                // paths.push(...matches);
                 continue;
             }
 
             if (fs.lstatSync(pathEntry).isDirectory()) {
+                const files = fs.readdirSync(pathEntry).map(file => path.join(pathEntry, file));
+                console.log('[ls] directory, adding files:', files);
                 preparedPaths.push(...fs.readdirSync(pathEntry).map(file => path.join(pathEntry, file)));
+                // preparedPaths.push(...files);
             } else {
+                console.log('[ls] file, adding:', pathEntry);
                 preparedPaths.push(pathEntry);
             }
         }
@@ -1092,33 +1138,52 @@ export function ls(optionsOrPaths?: unknown, ...paths: unknown[]): string[] {
         while (preparedPaths.length > 0) {
             const entry = preparedPaths.shift()!;
             const entrybasename = path.basename(entry);
+            console.log('[ls] processing prepared entry:', entry);
 
             if (entry?.includes('*')) {
                 preparedPaths.push(...findMatch(path.dirname(entry), [entrybasename]));
+                const matches = findMatch(path.dirname(entry), [entrybasename]);
+                console.log('[ls] wildcard in prepared entry, matches:', matches);
+                // preparedPaths.push(...matches);
                 continue;
             }
 
             if (!includeHidden && entrybasename.startsWith('.') && entrybasename !== '.' && entrybasename !== '..') {
+                console.log('[ls] skipping hidden file:', entry);
                 continue;
             }
             const baseDir = pathsCopy.find(p => entry.startsWith(path.resolve(p as string))) as string || path.resolve('.');
 
             if (fs.lstatSync(entry).isDirectory() && isRecursive) {
-                preparedPaths.push(...fs.readdirSync(entry).map(x => path.join(entry, x)));
+                const files = fs.readdirSync(entry).map(x => path.join(entry, x));
+                console.log('[ls] recursive directory, adding files:', files);
+                preparedPaths.push(...files);
                 entries.push(path.relative(baseDir, entry));
             } else {
+                console.log('[ls] adding entry:', path.relative(baseDir, entry));
                 entries.push(path.relative(baseDir, entry));
             }
         }
 
-        return entries;
+        // console.log('[ls] final entries:', entries);
+        // return entries;
+        const finalResults = [...results, ...entries];
+        console.log('[ls] final entries:', finalResults);
+        return finalResults;
     } catch (error) {
+        console.log('[ls] error:', error);
         if (error.code === 'ENOENT') {
             throw new Error(loc('LIB_PathNotFound', 'ls', error.message));
         } else {
             throw new Error(loc('LIB_OperationFailed', 'ls', error));
         }
     }
+}
+
+function flattenArray(arr: any[]): any[] {
+    return arr.reduce((flat, toFlatten) => {
+        return flat.concat(Array.isArray(toFlatten) ? flattenArray(toFlatten) : toFlatten);
+    }, []);
 }
 
 type CopyOptionsVariants = OptionsPermutations<'frn'>;

--- a/node/test/ls.ts
+++ b/node/test/ls.ts
@@ -296,4 +296,11 @@ describe('ls cases', () => {
 
     done();
   });
+
+  it('Provide filepaths only', (done) => {
+    const result = tl.ls([TEMP_FILE_1, TEMP_FILE_1_JS]);
+    assert.ok(result.includes(path.basename(TEMP_FILE_1)));
+    assert.ok(result.includes(path.basename(TEMP_FILE_1_JS)));
+    done();
+  });
 });


### PR DESCRIPTION
Explanation of the fix we implemented in the `ls` function for the single file input issue:

### Issue
- When providing a single file as input to `ls()`, it was returning an empty string because the relative path calculation was comparing the file path against itself.

### Fix Details
- We separated the handling of files and directories into two phases:
  ```typescript
  // Phase 1: Early file handling
  if (stats.isFile()) {
      // For files, just add the basename to results array
      const fileName = path.basename(pathEntry);
      results.push(fileName);
  } else {
      // Keep directories for later processing
      remainingPaths.push(pathEntry);
  }
  ```

### Key Changes
1. Files are processed first, before any directory traversal
2. For files, we simply extract and store the basename
3. Only directories continue to the existing relative path calculation logic

### Benefits
1. No changes to existing directory handling code
2. Maintains backward compatibility
3. Fixes the single file issue in ArchiveFiles@2 task
4. Clearer separation between file and directory processing

### Example
```yaml
- task: ArchiveFiles@2
  inputs:
    rootFolderOrFile: 'path/to/single/file.txt'
```
Now correctly adds the file to the archive with its proper name instead of an empty string.

### Link to modified canary pipeline with specific file archiving tests. 
This pipeline run is from my private organization which is run on archive file task linked locally to modified task-lib code. This includes new tests named `Test archive with specific file zip` for testing the change
https://dev.azure.com/rishabhmalikOrg/Test%20Project/_build/results?buildId=1040&view=logs&j=1809f88b-43e1-5a25-3102-9dca9646ed63