### PR TITLE
Adding unit tests in cp, mv and ls commands

### DIFF
--- a/node/test/cp.ts
+++ b/node/test/cp.ts
@@ -193,4 +193,34 @@ describe('cp cases', () => {
 
     done();
   });
+  it('Throws if no arguments are provided', (done) => {
+    assert.throws(() => (tl as any).cp(), /ENOENT|missing/i);
+    done();
+  });
+
+  it('Throws if only source is provided', (done) => {
+    assert.throws(() => (tl as any).cp('file1'), /ENOENT|missing/i);
+    done();
+  });
+
+  it('Recursive copy works with trailing slash', (done) => {
+    tl.mkdirP('dirA');
+    fs.writeFileSync(path.join('dirA', 'file.txt'), 'abc');
+    assert.doesNotThrow(() => tl.cp('-r', 'dirA/', 'dirB'));
+    assert.ok(fs.existsSync(path.join('dirB', 'dirA', 'file.txt')));
+    tl.rmRF('dirA');
+    tl.rmRF('dirB');
+    done();
+  });
+
+  it('Handles non-normalized paths', (done) => {
+    tl.mkdirP('dirC');
+    fs.writeFileSync(path.join('dirC', 'file.txt'), 'abc');
+    const nonNormalized = path.join('.', 'dirC', '.', '..', 'dirC');
+    assert.doesNotThrow(() => tl.cp('-r', nonNormalized, 'dirD'));
+    assert.ok(fs.existsSync(path.join('dirD', 'dirC', 'file.txt')));
+    tl.rmRF('dirC');
+    tl.rmRF('dirD');
+    done();
+  });
 });

--- a/node/test/ls.ts
+++ b/node/test/ls.ts
@@ -303,4 +303,32 @@ describe('ls cases', () => {
     assert.ok(result.includes(path.basename(TEMP_FILE_1_JS)));
     done();
   });
+
+  it('Handles directory with trailing slash', (done) => {
+    const result1 = tl.ls(TEMP_DIR_1);
+    const result2 = tl.ls(TEMP_DIR_1 + path.sep);
+    assert.deepStrictEqual(result1.sort(), result2.sort());
+    done();
+  });
+
+  it('Handles non-normalized paths', (done) => {
+    const nonNormalized = path.join(TEMP_DIR_1, '.', 'temp1_subdir1', '..', 'temp1_subdir1');
+    const result = tl.ls('-R', nonNormalized);
+    const expected = tl.ls('-R', TEMP_SUBDIR_1);
+    assert.deepStrictEqual(result.sort(), expected.sort());
+    done();
+  });
+
+  it('Handles multiple paths, some non-existent', (done) => {
+    assert.throws(() => tl.ls([TEMP_FILE_1, 'doesnotexist']), /Not found ls/);
+    done();
+  });
+
+  it('Handles empty directory', (done) => {
+    tl.mkdirP('emptydir');
+    const result = tl.ls('emptydir');
+    assert.strictEqual(result.length, 0);
+    tl.rmRF('emptydir');
+    done();
+  });
 });

--- a/node/test/mv.ts
+++ b/node/test/mv.ts
@@ -148,4 +148,21 @@ describe('mv cases', () => {
 
     done();
   });
+
+  it('No-clobber (-n) prevents overwrite', (done) => {
+    fs.writeFileSync('file1', 'a');
+    fs.writeFileSync('file2', 'b');
+    assert.throws(() => tl.mv('file1', 'file2', '-n'), /already exists/i);
+    assert.equal(fs.readFileSync('file2', 'utf8'), 'b');
+    done();
+  });
+
+  it('No-clobber (-n) with directory as destination', (done) => {
+    fs.mkdirSync('dir1');
+    fs.writeFileSync('file1', 'a');
+    fs.writeFileSync(path.join('dir1', 'file1'), 'b');
+    assert.throws(() => tl.mv('file1', 'dir1', '-n'), /already exists/i);
+    assert.equal(fs.readFileSync(path.join('dir1', 'file1'), 'utf8'), 'b');
+    done();
+  });
 });


### PR DESCRIPTION
Adding more tests in copy, move and ls command to improve resiliency. These tests are added after comparison of existing tests with the unit tests in shelljs implementation.