### PR TITLE
disabling automatic branch deletion

### DIFF
--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -58,6 +58,7 @@ stages:
         gitHubPatVariable: '$(GitHubPAT)'
         isAutoCompletePrSelected: true
         gitHubPrMergeMethod: 'squash'
+        isDeletePrSourceBranchSelected: false
       env:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 


### PR DESCRIPTION
There is an issue that when we run the [pipeline](https://mseng.visualstudio.com/PipelinesLocalization/_build/results?buildId=30666293&view=logs&j=3b94f880-87f8-584e-4049-e95fdb9e35af&t=55e3506f-7bbc-57c8-df7b-10915998b748), it automatically merges the [PR ](https://github.com/microsoft/azure-pipelines-task-lib/pull/1117/files)into the Localization branch and deletes the source branch. However, the pipeline then fails because it can't find the source branch, possibly due to a second deletion attempt. To test or reproduce this issue again with automatic deletion set to false.

Regarding more info about parameters of OneLocBuild Task visit this doc:
https://eng.ms/docs/cloud-ai-platform/azure-core/azure-experiences-and-ecosystems/cme-international-customer-exp/software-localization-onelocbuild/onelocbuild/onboarding/buildpipeline#:~:text=isDeletePrSourceBranchSelected,is%20true.