### PR TITLE
updating the vmimage versions

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ extends:
         baselineFile: $(Build.SourcesDirectory)/.gdn/.gdnbaselines
       sourceAnalysisPool:
         name: 1ES-ABTT-Shared-Pool
-        image: abtt-windows-2022
+        image: abtt-windows-2025
         os: windows
     customBuildTags:
     - ES365AIMigrationTooling
@@ -42,7 +42,7 @@ extends:
       #################################################
         pool:
           name: 1ES-ABTT-Shared-Pool
-          image: abtt-windows-2022
+          image: abtt-windows-2025
           os: windows
         steps:
         - template: /azure-pipelines-steps-node.yml@self
@@ -54,7 +54,7 @@ extends:
       #################################################
         pool:
           name: 1ES-ABTT-Shared-Pool
-          image: abtt-ubuntu-2204
+          image: abtt-ubuntu-2404
           os: linux
         templateContext:
           outputs:


### PR DESCRIPTION
Updating the VMImage versions

Error messages:
<img width="2027" height="209" alt="image" src="https://github.com/user-attachments/assets/d321da09-aa8c-493b-b5c6-4d9364145ca6" />
pipeline link: https://dev.azure.com/mseng/PipelineTools/_build/results?buildId=30861032&view=results

After making the changes:
<img width="1924" height="911" alt="image" src="https://github.com/user-attachments/assets/24ed5bec-71f8-4905-8254-1925792c6a4a" />
pipeline link: https://dev.azure.com/mseng/PipelineTools/_build/results?buildId=30865397&view=results

Work-item: [AB#2344099](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2344099)