### PR TITLE
updated script to use -UseBasicParsing

### DIFF
--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -22,7 +22,7 @@ stages:
       persistCredentials: true
       
     - powershell: |
-        $sprintInfo = Invoke-WebRequest https://whatsprintis.it -Headers @{"Accept"= "application/json"} | ConvertFrom-Json
+        $sprintInfo = Invoke-WebRequest https://whatsprintis.it -UseBasicParsing -Headers @{"Accept"= "application/json"} | ConvertFrom-Json
         if (($env:PR_CREATION_ENABLED -eq 'True') -and (($sprintInfo.week -eq 3) -or ($env:BUILD_REASON -eq 'Manual')))
         {
           Write-Host "shouldCreatePR was set to true"


### PR DESCRIPTION
Error: [pipeline](https://dev.azure.com/mseng/PipelinesLocalization/_build/results?buildId=30861817&view=logs&j=3b94f880-87f8-584e-4049-e95fdb9e35af&t=a0643e5f-04e3-51ab-03b5-557c8a3144c1)

<img width="1268" height="225" alt="image" src="https://github.com/user-attachments/assets/aff610c2-fcec-4e1e-82c9-9db4f81cdf8b" />

### **Root Cause:**
Brief summary from https://support.microsoft.com/en-us/topic/powershell-5-1-invoke-webrequest-preventing-script-execution-from-web-content-7cb95559-655e-43fd-a8bd-ceef2406b705

Microsoft introduced this security change to **prevent malicious script execution** from web content fetched by PowerShell scripts. Before this update, PowerShell 5.1's` Invoke-WebRequest` used Internet Explorer's HTML parsing engine, which could **silently execute JavaScript** from downloaded web pages, creating a security vulnerability.

**What Changed:**
- **Before Dec 9, 2025:** `Invoke-WebRequest `automatically parsed HTML using IE engine, potentially running embedded scripts
- **After Dec 9, 2025:** PowerShell 5.1 now **prompts for confirmation** before parsing web content (or fails in non-interactive/automated scenarios)

**The Problem:**
In **non-interactive environments** (CI/CD pipelines, scheduled tasks), the security prompt causes scripts to **hang or fail** because there's no one to respond to the prompt.

**The Solution:**
Add **`-UseBasicParsing`** parameter to skip the IE engine and safely retrieve content without executing scripts:

`Invoke-WebRequest https://url -UseBasicParsing`

### **Testing & Validation**

success [pipeline](https://dev.azure.com/mseng/PipelinesLocalization/_build/results?buildId=30865887&view=logs&j=3b94f880-87f8-584e-4049-e95fdb9e35af&t=a0643e5f-04e3-51ab-03b5-557c8a3144c1):