### PR TITLE
Split PR and release pipelines

### DIFF
--- a/.azure-pipelines/release-pipeline.yml
+++ b/.azure-pipelines/release-pipeline.yml
@@ -1,8 +1,12 @@
-# PR validation pipeline - build and test only, no publishing
-# The Task 'PublishPipelineArtifact@1' has been converted to an output named '' in the templateContext section.
-trigger: none
+# CI/Release pipeline - triggers on merge to master/releases, builds, tests, and publishes packages
+# This pipeline will be extended to the OneESPT template
+trigger:
+- master
+- features/*
+- releases/*
 
 variables:
+- group: npm-tokens
 - name: nodeVersion
   value: '16.13.0'
 - name: nodeVersionForPowershell
@@ -42,7 +46,7 @@ extends:
         steps:
         - template: /azure-pipelines-steps-node.yml@self
           parameters:
-            os: Windows_NT  
+            os: Windows_NT
 
       #################################################
       - job: linux
@@ -61,6 +65,15 @@ extends:
         - template: /azure-pipelines-steps-node.yml@self
           parameters:
             os: Linux
+
+        - bash: |
+            echo //registry.npmjs.org/:_authToken=\${NPM_TOKEN} > .npmrc
+            npm publish || true # Ignore publish failures, usually will happen because package already exists
+          displayName: (task-lib) npm publish
+          workingDirectory: node/_build
+          condition: and(succeeded(), in(variables['build.reason'], 'IndividualCI', 'BatchedCI', 'Manual'), in(variables['build.sourcebranch'], 'refs/heads/master'))
+          env:
+            NPM_TOKEN: $(npm-automation.token)
 
       #################################################
       - job: macOS

--- a/azure-pipelines-steps-node.yml
+++ b/azure-pipelines-steps-node.yml
@@ -20,19 +20,8 @@ steps:
   workingDirectory: node
   displayName: (task-lib) npm test
 
-# Only on Linux. For CI runs on master, automatically publish packages
-- ${{ if eq(parameters.os, 'Linux') }}:
-  - bash: |
-      echo //registry.npmjs.org/:_authToken=\${NPM_TOKEN} > .npmrc
-      npm publish || true # Ignore publish failures, usually will happen because package already exists
-    displayName: (task-lib) npm publish
-    workingDirectory: node/_build
-    condition: and(succeeded(), in(variables['build.reason'], 'IndividualCI', 'BatchedCI', 'Manual'), in(variables['build.sourcebranch'], 'refs/heads/master'))
-    env:
-      NPM_TOKEN: $(npm-automation.token)
-
-  # PublishPipelineArtifact step is configured in the base template.
-  # See the templateContext section in the azure-pipelines.yml file
+# Only on Linux. PublishPipelineArtifact step is configured in the base template.
+# See the templateContext section in the azure-pipelines.yml file
 
 # Only on Windows. Build VstsTaskSdk for powershell 
 - ${{ if eq(parameters.os, 'Windows_NT') }}:


### PR DESCRIPTION
## Summary
Separates the PR validation pipeline from the CI/release pipeline so that PR builds don't reference npm tokens.

### Changes
- **`azure-pipelines.yml`** — Now PR-only: `trigger: none`, no `npm-tokens` variable group
- **`azure-pipelines-steps-node.yml`** — Pure build+test steps template (publish step removed), reused by both pipelines
- **New `.azure-pipelines/release-pipeline.yml`** — CI trigger on `master`/`features/*`/`releases/*`, includes `npm-tokens` group, appends publish step after the shared template steps (linux job only)

### How it works
- **PR pipeline**: build + test on Windows/Linux/macOS (no secrets)
- **Release pipeline**: build + test + publish (single job per OS, publish on Linux only, reuses shared template)