### PR TITLE
Update minimatch to v10.2.4 and fix NodeJS.Timer type compatibility

### DIFF
--- a/node/internal.ts
+++ b/node/internal.ts
@@ -600,6 +600,7 @@ export interface _MatchOptions {
     nocomment?: boolean;
     nonegate?: boolean;
     flipNegate?: boolean;
+    windowsPathsNoEscape?: boolean;
 }
 
 export function _cloneMatchOptions(matchOptions: _MatchOptions): _MatchOptions {
@@ -614,7 +615,8 @@ export function _cloneMatchOptions(matchOptions: _MatchOptions): _MatchOptions {
         matchBase: matchOptions.matchBase,
         nocomment: matchOptions.nocomment,
         nonegate: matchOptions.nonegate,
-        flipNegate: matchOptions.flipNegate
+        flipNegate: matchOptions.flipNegate,
+        windowsPathsNoEscape: matchOptions.windowsPathsNoEscape
     };
 }
 
@@ -646,6 +648,9 @@ export function _getFindInfoFromPattern(defaultRoot: string, pattern: string, ma
     // for the sake of determining the findPath, pretend nocase=false
     matchOptions = _cloneMatchOptions(matchOptions);
     matchOptions.nocase = false;
+    if (process.platform == 'win32' && matchOptions.windowsPathsNoEscape === undefined) {
+        matchOptions.windowsPathsNoEscape = true;
+    }
 
     // check if basename only and matchBase=true
     if (matchOptions.matchBase &&

--- a/node/mock-task.ts
+++ b/node/mock-task.ts
@@ -392,6 +392,7 @@ export interface MatchOptions {
     nocomment?: boolean;
     nonegate?: boolean;
     flipNegate?: boolean;
+    windowsPathsNoEscape?: boolean;
 }
 
 export function findMatch(defaultRoot: string, patterns: string[] | string) : string[] {

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "5.2.9",
+  "version": "5.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "azure-pipelines-task-lib",
-      "version": "5.2.9",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
-        "minimatch": "^3.1.5",
+        "minimatch": "^10.2.4",
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
@@ -18,7 +18,6 @@
         "uuid": "^3.0.1"
       },
       "devDependencies": {
-        "@types/minimatch": "3.0.3",
         "@types/mocha": "^10.0.10",
         "@types/node": "^16.11.39",
         "@types/q": "^1.5.4",
@@ -26,29 +25,6 @@
         "@types/shelljs": "^0.8.17",
         "mocha": "^11.7.5",
         "typescript": "^4.9.5"
-      }
-    },
-    "node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-      "integrity": "sha1-MIHa28NGBmG3UedZHX+upd853Sk=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-      "integrity": "sha1-Sz2rq32OdaQpQUqWvWe/TB0T4PM=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -114,13 +90,6 @@
       "engines": {
         "node": ">=14"
       }
-    },
-    "node_modules/@types/minimatch": {
-      "version": "3.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha1-PcoOPzOyAPx9ETnAzZbBJoyt/Z0=",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/mocha": {
       "version": "10.0.10",
@@ -222,16 +191,28 @@
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "version": "5.0.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha1-3MOjcRa3nz4bRtuZTO1dVw6TD9s=",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha1-v7EGYv7tgZaixi58aOF3IMJ0F5o=",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -408,12 +389,6 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -695,22 +670,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "10.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-10.1.1.tgz",
-      "integrity": "sha1-5uYbmwwdyrEWtafRRY6LaunnOlU=",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-flag/-/has-flag-4.0.0.tgz",
@@ -861,9 +820,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha1-wftl+PUBeQHN0slRhkuhhFihBgI=",
+      "version": "4.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha1-hUwpJGdwW2mUduGi3swMijRYgGs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -975,15 +934,18 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
-      "license": "ISC",
+      "version": "10.2.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha1-Rls6zL0CGLgoH1MB4nztxpf5b94=",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minipass": {
@@ -1088,13 +1050,13 @@
       "license": "ISC"
     },
     "node_modules/mocha/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha1-10+d1rV9g9jpjPuCEzsDl4vJKeU=",
+      "version": "9.0.9",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha1-mwy5/LeAh/b9fqur4lEcTT1gV04=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -1255,9 +1217,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI=",
+      "version": "2.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha1-WpQpFeJrNy3A8OZ1MUmhbmscVgE=",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "5.2.9",
+  "version": "5.3.0",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/Microsoft/azure-pipelines-task-lib",
   "dependencies": {
     "adm-zip": "^0.5.10",
-    "minimatch": "^3.1.5",
+    "minimatch": "^10.2.4",
     "nodejs-file-downloader": "^4.11.1",
     "q": "^1.5.1",
     "semver": "^5.7.2",
@@ -36,7 +36,6 @@
     "uuid": "^3.0.1"
   },
   "devDependencies": {
-    "@types/minimatch": "3.0.3",
     "@types/mocha": "^10.0.10",
     "@types/node": "^16.11.39",
     "@types/q": "^1.5.4",

--- a/node/task.ts
+++ b/node/task.ts
@@ -1983,6 +1983,7 @@ export interface MatchOptions {
     nocomment?: boolean;
     nonegate?: boolean;
     flipNegate?: boolean;
+    windowsPathsNoEscape?: boolean;
 }
 
 /**
@@ -1997,6 +1998,9 @@ export function match(list: string[], patterns: string[] | string, patternRoot?:
     // trace parameters
     debug(`patternRoot: '${patternRoot}'`);
     options = options || _getDefaultMatchOptions(); // default match options
+    if (process.platform == 'win32' && options.windowsPathsNoEscape === undefined) {
+        options.windowsPathsNoEscape = true;
+    }
     _debugMatchOptions(options);
 
     // convert pattern to an array
@@ -2129,6 +2133,9 @@ export function match(list: string[], patterns: string[] | string, patternRoot?:
  */
 export function filter(pattern: string, options?: MatchOptions): (element: string, indexed: number, array: string[]) => boolean {
     options = options || _getDefaultMatchOptions();
+    if (process.platform == 'win32' && options.windowsPathsNoEscape === undefined) {
+        options.windowsPathsNoEscape = true;
+    }
     return minimatch.filter(pattern, options);
 }
 
@@ -2144,6 +2151,7 @@ function _debugMatchOptions(options: MatchOptions): void {
     debug(`matchOptions.nocomment: '${options.nocomment}'`);
     debug(`matchOptions.nonegate: '${options.nonegate}'`);
     debug(`matchOptions.flipNegate: '${options.flipNegate}'`);
+    debug(`matchOptions.windowsPathsNoEscape: '${options.windowsPathsNoEscape}'`);
 }
 
 function _getDefaultMatchOptions(): MatchOptions {
@@ -2158,7 +2166,8 @@ function _getDefaultMatchOptions(): MatchOptions {
         matchBase: false,
         nocomment: false,
         nonegate: false,
-        flipNegate: false
+        flipNegate: false,
+        windowsPathsNoEscape: process.platform == 'win32'
     };
 }
 
@@ -2182,6 +2191,9 @@ export function findMatch(defaultRoot: string, patterns: string[] | string, find
     findOptions = findOptions || _getDefaultFindOptions();
     _debugFindOptions(findOptions);
     matchOptions = matchOptions || _getDefaultMatchOptions();
+    if (process.platform == 'win32' && matchOptions.windowsPathsNoEscape === undefined) {
+        matchOptions.windowsPathsNoEscape = true;
+    }
     _debugMatchOptions(matchOptions);
 
     // normalize slashes for root dir

--- a/node/toolrunner.ts
+++ b/node/toolrunner.ts
@@ -1422,7 +1422,7 @@ class ExecState extends events.EventEmitter {
     private readonly options: IExecOptions;
     private readonly toolPath: string;
 
-    private timeout: NodeJS.Timer | null = null;
+    private timeout: ReturnType<typeof setTimeout> | null = null;
     private done: boolean;
 
     public CheckComplete(): void {


### PR DESCRIPTION

**Description:**

### Summary

Updates `minimatch` from v3.1.5 to v10.2.4 and addresses compatibility issues for Windows path handling and newer `@types/node` versions.

### Changes

- **Upgraded `minimatch`** from `^3.1.5` to `^10.2.4`
- **Removed `@types/minimatch`** devDependency (types are now bundled in minimatch v5+)
- **Added `windowsPathsNoEscape` support** across internal.ts, task.ts, and mock-task.ts to preserve Windows backslash-as-path-separator behavior
- **Fixed `NodeJS.Timer` type** in toolrunner.ts — replaced deprecated `NodeJS.Timer` with `ReturnType<typeof setTimeout>` for compatibility with `@types/node@20+`
- **Version bump** to `5.3.0`

### Why

minimatch v3 is outdated and unmaintained. Starting from v5, minimatch treats `\` as a glob escape character instead of a path separator. This breaks Windows path matching (e.g., `C:\src\*.js`). The `windowsPathsNoEscape: true` option is now auto-applied on Windows to restore the expected behavior.

The `NodeJS.Timer` type was deprecated in newer `@types/node`. Tasks compiled with `@types/node@20` or `@types/node@24` would encounter type errors when resolving the task-lib's `.ts` source files.

### Backward Compatibility

- No public API changes — all function signatures and return types remain the same
- `windowsPathsNoEscape` is only auto-set on Windows when not explicitly provided by the caller
- Existing tasks require zero code changes

### Testing

- All **554 tests pass** (0 failures, 2 pre-existing pending)
- Verified locally with `npm pack` from `_build/` and tested against DockerV2 and AzureFileCopyV6 task

### Risk

**Low** — On Windows, the new option restores identical behavior to minimatch v3. On Linux/macOS, nothing changed. No existing task sets `windowsPathsNoEscape`, so the auto-default always applies.

### Files Changed

| File | Change |
|---|---|
| package.json | Updated `minimatch`, removed `@types/minimatch`, version bump |
| internal.ts | Added `windowsPathsNoEscape` to interface, clone function, `_getFindInfoFromPattern()` |
| task.ts | Added `windowsPathsNoEscape` to interface, defaults, `match()`, `findMatch()`, `filter()` |
| mock-task.ts | Added `windowsPathsNoEscape` to interface |
| toolrunner.ts | `NodeJS.Timer` → `ReturnType<typeof setTimeout>` |

---