### PR TITLE
Fix glob patterns in the cp function

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "5.2.9",
+  "version": "5.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "azure-pipelines-task-lib",
-      "version": "5.2.9",
+      "version": "5.2.10",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "5.2.9",
+  "version": "5.2.10",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",

--- a/node/task.ts
+++ b/node/task.ts
@@ -1232,7 +1232,7 @@ export function cp(sourceOrOptions: unknown, destinationOrSource: string, option
         if (!fs.existsSync(destination) && !force) {
             throw new Error(loc('LIB_PathNotFound', 'cp', destination));
         }
-        const hasGlobPattern =  /[*?{[!@#]/.test(source);
+        const hasGlobPattern =  /[*?{!\[]/.test(source) || /^[#]/.test(source) || /[@+]\(/.test(source);
         if (hasGlobPattern) {
             let sourcesToProcess: string[] = [];
             let sourceDir = path.dirname(source);

--- a/node/task.ts
+++ b/node/task.ts
@@ -1232,14 +1232,14 @@ export function cp(sourceOrOptions: unknown, destinationOrSource: string, option
         if (!fs.existsSync(destination) && !force) {
             throw new Error(loc('LIB_PathNotFound', 'cp', destination));
         }
-        const hasGlobPattern =  /[*?{!\[]/.test(source) || /^[#]/.test(source) || /[@+]\(/.test(source);
-        if (hasGlobPattern) {
+        const isPattern = /[*?{\[]/.test(source) || /^[#!]/.test(source) || /[@+!]\(/.test(source);
+        if (isPattern) {
             let sourcesToProcess: string[] = [];
             let sourceDir = path.dirname(source);
             sourceDir = sourceDir == '.' ? path.resolve() : sourceDir;
             sourcesToProcess = findMatch(sourceDir, [path.basename(source)]);
             if (sourcesToProcess.length === 0) {
-                debug(`No matches found for glob pattern: ${source}`);
+                debug(`No matches found for pattern: ${source}`);
             }
             for (const src of sourcesToProcess) {
                 cp(src, destination, options as CopyOptionsVariants, continueOnError, retryCount);

--- a/node/test/cp.ts
+++ b/node/test/cp.ts
@@ -301,6 +301,33 @@ describe('cp cases', () => {
     done();
   });
 
+  it('cp with @() extglob pattern', (done) => {
+    const pattern = path.join(GLOB_TEST_DIR, '@(file1|file2).txt');
+    assert.doesNotThrow(() => tl.cp(pattern, GLOB_DEST_DIR));
+
+    assert.ok(fs.existsSync(path.join(GLOB_DEST_DIR, 'file1.txt')));
+    assert.ok(fs.existsSync(path.join(GLOB_DEST_DIR, 'file2.txt')));
+    assert.ok(!fs.existsSync(path.join(GLOB_DEST_DIR, 'test.txt')));
+    assert.ok(!fs.existsSync(path.join(GLOB_DEST_DIR, 'file3.log')));
+
+    done();
+  });
+
+  it('cp handles literal @ in path', (done) => {
+    const srcDir = path.resolve(DIRNAME, 'dir@test');
+    const destDir = path.resolve(DIRNAME, 'dest-at');
+    tl.mkdirP(srcDir);
+    tl.mkdirP(destDir);
+    fs.writeFileSync(path.join(srcDir, 'file.txt'), 'content');
+    
+    assert.doesNotThrow(() => tl.cp(path.join(srcDir, 'file.txt'), destDir));
+    assert.ok(fs.existsSync(path.join(destDir, 'file.txt')));
+    
+    tl.rmRF(srcDir);
+    tl.rmRF(destDir);
+    done();
+  });
+
   it('Handles non-normalized paths', (done) => {
     tl.mkdirP('dirC');
     fs.writeFileSync(path.join('dirC', 'file.txt'), 'abc');

--- a/node/test/cp.ts
+++ b/node/test/cp.ts
@@ -266,6 +266,17 @@ describe('cp cases', () => {
     done();
   });
 
+  it('cp with ! pattern2', (done) => {
+    const pattern = path.join(GLOB_TEST_DIR, 'file?.!(txt)');
+    assert.doesNotThrow(() => tl.cp(pattern, GLOB_DEST_DIR));
+    assert.ok(!fs.existsSync(path.join(GLOB_DEST_DIR, 'file1.txt')));
+    assert.ok(!fs.existsSync(path.join(GLOB_DEST_DIR, 'file2.txt')));
+    assert.ok(!fs.existsSync(path.join(GLOB_DEST_DIR, 'test.txt')));
+    assert.ok(fs.existsSync(path.join(GLOB_DEST_DIR, 'file3.log')));
+
+    done();
+  });
+
   it('cp with ? pattern matches single character', (done) => {
     
     const pattern = path.join(GLOB_TEST_DIR, 'file?.txt');
@@ -315,7 +326,7 @@ describe('cp cases', () => {
 
   it('cp handles literal @ in path', (done) => {
     const srcDir = path.resolve(DIRNAME, 'dir@test');
-    const destDir = path.resolve(DIRNAME, 'dest-at');
+    const destDir = path.resolve(DIRNAME, 'dest');
     tl.mkdirP(srcDir);
     tl.mkdirP(destDir);
     fs.writeFileSync(path.join(srcDir, 'file.txt'), 'content');


### PR DESCRIPTION
 ### Problem
 The `cp` function's glob pattern regex (`/[*?{[!@#]/.test(source)`) incorrectly treated a literal `@` character in file paths as an extglob pattern. The `@` symbol is only a glob operator when used as `@(...)`, but the old regex matched a standalone `@` anywhere in the path. This caused the function to enter the glob resolution branch, leading to an infinite loop and `RangeError: Maximum call stack size exceeded`.
 
 ### Fix
 Updated the glob detection regex to correctly distinguish between:
 - **Glob operators**: `*`, `?`, `{`, `[` — matched as before
 - **`#` comments**: only at the start of the string (`/^[#!]/.test(source)`)
 - **Extglob `@(...)`**: requires `@` (or `+`,`!`) followed by `(` (`/[@+!]\(/.test(source)`)
 
 A standalone `@` in a path (e.g., `dir@test/file.txt`) is no longer 
 misidentified as a glob pattern.
 
 ### Changes
 - **`node/task.ts`** — Updated `hasGlobPattern` regex in `cp` function
 - **`node/package.json`** — Version bump 5.2.9 → 5.2.10
 - **`node/tests/cp.test.ts`** — Added tests for:
   - `@()` extglob pattern matching (e.g., `@(file1|file2).txt`)
   - Literal `@` in directory paths (e.g., `dir@test/file.txt`)
 
 ### Fixes
 - #1166
 - microsoft/azure-pipelines-tasks#21987