### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 10947: Build ID 31380895

### DIFF
--- a/node/Strings/resources.resjson/de-DE/resources.resjson
+++ b/node/Strings/resources.resjson/de-DE/resources.resjson
@@ -1,4 +1,5 @@
 {
+  "loc.messages.LIB_CopyDirectoryWithoutRecursiveOption": "cp: cannot copy a directory '%s' without the recursive option",
   "loc.messages.LIB_CopyFileFailed": "Fehler beim Kopieren der Datei. Verbleibende Versuche: %s",
   "loc.messages.LIB_DirectoryStackEmpty": "Der Verzeichnisstapel ist leer.",
   "loc.messages.LIB_EndpointAuthNotExist": "Die Endpunkt-Authentifizierungsdatensind nicht vorhanden: %s",

--- a/node/Strings/resources.resjson/es-ES/resources.resjson
+++ b/node/Strings/resources.resjson/es-ES/resources.resjson
@@ -1,4 +1,5 @@
 {
+  "loc.messages.LIB_CopyDirectoryWithoutRecursiveOption": "cp: cannot copy a directory '%s' without the recursive option",
   "loc.messages.LIB_CopyFileFailed": "Error al copiar el archivo. Intentos restantes: %s",
   "loc.messages.LIB_DirectoryStackEmpty": "La pila de directorios está vacía",
   "loc.messages.LIB_EndpointAuthNotExist": "Los datos de autenticación del punto de conexión no existen: %s.",

--- a/node/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/node/Strings/resources.resjson/fr-FR/resources.resjson
@@ -1,4 +1,5 @@
 {
+  "loc.messages.LIB_CopyDirectoryWithoutRecursiveOption": "cp: cannot copy a directory '%s' without the recursive option",
   "loc.messages.LIB_CopyFileFailed": "Erreur durant la copie du fichier. Tentatives restantes : %s",
   "loc.messages.LIB_DirectoryStackEmpty": "La pile de répertoires est vide",
   "loc.messages.LIB_EndpointAuthNotExist": "Données d'authentification du point de terminaison absentes : %s",

--- a/node/Strings/resources.resjson/it-IT/resources.resjson
+++ b/node/Strings/resources.resjson/it-IT/resources.resjson
@@ -1,4 +1,5 @@
 {
+  "loc.messages.LIB_CopyDirectoryWithoutRecursiveOption": "cp: cannot copy a directory '%s' without the recursive option",
   "loc.messages.LIB_CopyFileFailed": "Si è verificato un errore durante la copia del file. Tentativi rimasti: %s",
   "loc.messages.LIB_DirectoryStackEmpty": "Lo stack della directory è vuoto",
   "loc.messages.LIB_EndpointAuthNotExist": "I dati di autenticazione endpoint non sono presenti: %s",

--- a/node/Strings/resources.resjson/ja-JP/resources.resjson
+++ b/node/Strings/resources.resjson/ja-JP/resources.resjson
@@ -1,4 +1,5 @@
 {
+  "loc.messages.LIB_CopyDirectoryWithoutRecursiveOption": "cp: cannot copy a directory '%s' without the recursive option",
   "loc.messages.LIB_CopyFileFailed": "ファイルのコピー中にエラーが発生しました。残りの試行回数: %s",
   "loc.messages.LIB_DirectoryStackEmpty": "ディレクトリ スタックが空です",
   "loc.messages.LIB_EndpointAuthNotExist": "エンドポイントの認証データがありません: %s",

--- a/node/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/node/Strings/resources.resjson/ko-KR/resources.resjson
@@ -1,4 +1,5 @@
 {
+  "loc.messages.LIB_CopyDirectoryWithoutRecursiveOption": "cp: cannot copy a directory '%s' without the recursive option",
   "loc.messages.LIB_CopyFileFailed": "파일을 복사하는 동안 오류가 발생했습니다. 남은 시도 횟수: %s",
   "loc.messages.LIB_DirectoryStackEmpty": "디렉터리 스택이 비어 있습니다.",
   "loc.messages.LIB_EndpointAuthNotExist": "엔드포인트 인증 데이터가 없음: %s",

--- a/node/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/node/Strings/resources.resjson/ru-RU/resources.resjson
@@ -1,4 +1,5 @@
 {
+  "loc.messages.LIB_CopyDirectoryWithoutRecursiveOption": "cp: cannot copy a directory '%s' without the recursive option",
   "loc.messages.LIB_CopyFileFailed": "Ошибка при копировании файла. Оставшееся число попыток: %s.",
   "loc.messages.LIB_DirectoryStackEmpty": "Стек каталога пуст",
   "loc.messages.LIB_EndpointAuthNotExist": "Отсутствуют данные для проверки подлинности конечной точки: %s",

--- a/node/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/node/Strings/resources.resjson/zh-CN/resources.resjson
@@ -1,4 +1,5 @@
 {
+  "loc.messages.LIB_CopyDirectoryWithoutRecursiveOption": "cp: cannot copy a directory '%s' without the recursive option",
   "loc.messages.LIB_CopyFileFailed": "复制文件时出错。剩余尝试次数: %s",
   "loc.messages.LIB_DirectoryStackEmpty": "目录堆栈为空",
   "loc.messages.LIB_EndpointAuthNotExist": "终结点授权数据不存在: %s",

--- a/node/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/node/Strings/resources.resjson/zh-TW/resources.resjson
@@ -1,4 +1,5 @@
 {
+  "loc.messages.LIB_CopyDirectoryWithoutRecursiveOption": "cp: cannot copy a directory '%s' without the recursive option",
   "loc.messages.LIB_CopyFileFailed": "複製檔案時發生錯誤。剩餘嘗試次數: %s",
   "loc.messages.LIB_DirectoryStackEmpty": "目錄堆疊是空的",
   "loc.messages.LIB_EndpointAuthNotExist": "端點驗證資料不存在: %s",


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.