### PR TITLE
package feed updates

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="PipelineTools_PublicPackages" value="https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/azure-pipelines-steps-node.yml
+++ b/azure-pipelines-steps-node.yml
@@ -36,6 +36,15 @@ steps:
 
 # Only on Windows. Build VstsTaskSdk for powershell 
 - ${{ if eq(parameters.os, 'Windows_NT') }}:
+  # Restore NuGet packages from internal feed (CFS compliant)
+  - task: DotNetCoreCLI@2
+    displayName: 'Restore .NET project(s)'
+    inputs:
+      command: restore
+      projects: 'powershell/CompiledHelpers/VstsTaskSdk.csproj'
+      feedsToUse: config
+      nugetConfigPath: 'NuGet.Config'
+
   # Build step for .NET source code. This is needed to enable CodeQL for C# code
   - task: DotNetCoreCLI@2
     displayName: 'Build .NET project(s)'

--- a/azure-pipelines-steps-node.yml
+++ b/azure-pipelines-steps-node.yml
@@ -42,7 +42,7 @@ steps:
     inputs:
       command: build
       projects: 'powershell/CompiledHelpers/VstsTaskSdk.csproj'
-      arguments: '--configuration Release'
+      arguments: '--configuration Release --no-restore'
 
   - task: NodeTool@0
     displayName: use node $(nodeVersionForPowershell) for PowerShell SDK


### PR DESCRIPTION
### **Context**
This PR addresses CFS (Central Feed Services) compliance violation for SFI-ES4.2.4 (Network Isolation) detected in the task-lib CI pipeline.

[AB#2387584](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2387584)

---

### **Description**
Two changes to eliminate `api.nuget.org` calls flagged by the CFS detector during the .NET build step:

1. **Added `NuGet.Config` at repo root**: Contains `<clear />` to remove default nuget.org source and adds the internal `PipelineTools_PublicPackages` ADO feed as the sole package source.

2. **Split build into restore + build steps**: 
   - Added an explicit `DotNetCoreCLI@2` restore step using `feedsToUse: config` with the new `NuGet.Config` — this ensures package restore goes through the internal feed only.
   - Added `--no-restore` to the build step to prevent it from triggering an implicit restore that would hit nuget.org.

---

### **Risk Assessment** (Low / Medium / High)  
**Low**
- The .csproj has no PackageReference dependencies — restore is essentially a no-op that generates `project.assets.json`. 
- No behavioral change to the task-lib itself; only affects how the CI pipeline resolves packages.

---

### **Unit Tests Added or Updated** (Yes / No)  
No — CI pipeline configuration change only, no library code modified.

---

### **Additional Testing Performed**
- Ran CI pipeline build to validate the restore + build steps succeed.
- Verified `PipelineTools_PublicPackages` feed is accessible from the pipeline.

--- 

### **Change Behind Feature Flag** (Yes / No)
No — build infrastructure change, not runtime behavior. Feature flags are not applicable.

---

### **Tech Design / Approach**
- `NuGet.Config` with `<clear />` ensures no implicit nuget.org fallback.
- Separate restore step with `feedsToUse: config` gives explicit control over package source resolution.
- `--no-restore` on build prevents double-restore and ensures the build never independently contacts nuget.org.

---

### **Documentation Changes Required** (Yes/No)
No — internal CI pipeline changes only.

---
### **Logging Added/Updated** (Yes/No)
No — no runtime code changes.

--- 

### **Telemetry Added/Updated** (Yes/No) 
No — no runtime code changes.

---

### **Rollback Scenario and Process** (Yes/No)
- Rollback: revert the PR. The build will resume using default nuget.org source.

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
Yes — the .csproj has no external PackageReference dependencies, so the feed change has no functional impact on package resolution.