### PR TITLE
Fix infinite loop when using `[` or `]` in paths

### DIFF
--- a/node/task.ts
+++ b/node/task.ts
@@ -1242,6 +1242,15 @@ export function cp(sourceOrOptions: unknown, destinationOrSource: string, option
                 debug(`No matches found for pattern: ${source}`);
             }
             for (const src of sourcesToProcess) {
+                if (path.resolve(src) === path.resolve(source)) {
+                    // Literal path that was mistakenly treated as a glob pattern.
+                    // Copy directly without recursing to prevent infinite recursion.
+                    const dest = fs.existsSync(destination) && fs.lstatSync(destination).isDirectory()
+                        ? path.join(destination, path.basename(src))
+                        : destination;
+                    copyWithPreservedSymlinks(src, dest, force);
+                    continue;
+                }
                 cp(src, destination, options as CopyOptionsVariants, continueOnError, retryCount);
             }
             return;

--- a/node/test/cp.ts
+++ b/node/test/cp.ts
@@ -349,4 +349,20 @@ describe('cp cases', () => {
     tl.rmRF('dirD');
     done();
   });
+
+  it('cp handles literal [ and ] in path without infinite recursion', (done) => {
+    const srcDir = path.resolve(DIRNAME, '[Test] dir');
+    const destDir = path.resolve(DIRNAME, '[d]est');
+    tl.mkdirP(srcDir);
+    tl.mkdirP(destDir);
+    fs.writeFileSync(path.join(srcDir, 'file.txt'), 'content');
+
+    assert.doesNotThrow(() => tl.cp(path.join(srcDir, 'file.txt'), destDir));
+    assert.ok(fs.existsSync(path.join(destDir, 'file.txt')));
+    assert.equal(fs.readFileSync(path.join(destDir, 'file.txt'), 'utf8'), 'content');
+
+    tl.rmRF(srcDir);
+    tl.rmRF(destDir);
+    done();
+  });
 });


### PR DESCRIPTION
## Problem
Using `[` and/or `]` in a path (directory or filename) will result in an endless loop causing: Maximum call stack size exceeded

## Fix
Stop the loop when the matched value is the same as the source value. 

## Changes
- `node/task.ts` — Additional `if` statement added  to check if the new `src` in `sourcesToProcess` differs from the original `source`
- `node/tests/cp.ts` — Test added with `[` and `]` in directory and filename

## Fixes
#1166




