### PR TITLE
Fix glob pattern handling in cp to prevent infinite recursion and support full-path patterns

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "5.2.10",
+  "version": "5.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "azure-pipelines-task-lib",
-      "version": "5.2.10",
+      "version": "5.2.11",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "5.2.10",
+  "version": "5.2.11",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",

--- a/node/task.ts
+++ b/node/task.ts
@@ -1232,19 +1232,18 @@ export function cp(sourceOrOptions: unknown, destinationOrSource: string, option
         if (!fs.existsSync(destination) && !force) {
             throw new Error(loc('LIB_PathNotFound', 'cp', destination));
         }
-        const isPattern = /[*?{\[]/.test(source) || /^[#!]/.test(source) || /[@+!]\(/.test(source);
+        const isPattern = /[*?{\[]/.test(source) || /[@+!]\(/.test(source);
         if (isPattern) {
-            let sourcesToProcess: string[] = [];
-            let sourceDir = path.dirname(source);
-            sourceDir = sourceDir == '.' ? path.resolve() : sourceDir;
-            sourcesToProcess = findMatch(sourceDir, [path.basename(source)]);
-            if (sourcesToProcess.length === 0) {
-                debug(`No matches found for pattern: ${source}`);
+           const defaultRoot = getVariable('system.defaultWorkingDirectory') || process.cwd();
+            const sourcesToProcess = findMatch(defaultRoot, [source], undefined, <MatchOptions>{nonegate: true, nocomment: true});
+            if (sourcesToProcess.length > 0) {
+                for (const src of sourcesToProcess) {
+                    cp(src, destination, options as CopyOptionsVariants, continueOnError, retryCount);
+                }
+                return;
+            } else {
+                debug(`No matches found for the pattern: ${source}. Fallback to check for the literal path.`);
             }
-            for (const src of sourcesToProcess) {
-                cp(src, destination, options as CopyOptionsVariants, continueOnError, retryCount);
-            }
-            return;
         }
         var lstatSource = fs.lstatSync(source);
 

--- a/node/task.ts
+++ b/node/task.ts
@@ -1234,7 +1234,7 @@ export function cp(sourceOrOptions: unknown, destinationOrSource: string, option
         }
         const isPattern = /[*?{\[]/.test(source) || /[@+!]\(/.test(source);
         if (isPattern) {
-           const defaultRoot = getVariable('system.defaultWorkingDirectory') || process.cwd();
+            const defaultRoot = getVariable('system.defaultWorkingDirectory') || process.cwd();
             const sourcesToProcess = findMatch(defaultRoot, [source], undefined, <MatchOptions>{nonegate: true, nocomment: true});
             if (sourcesToProcess.length > 0) {
                 for (const src of sourcesToProcess) {

--- a/node/test/cp.ts
+++ b/node/test/cp.ts
@@ -346,7 +346,7 @@ describe('cp cases', () => {
     tl.mkdirP(destDir);
     fs.writeFileSync(path.join(srcDir, 'file.txt'), 'content');
 
-    assert.doesNotThrow(() => tl.cp(path.join(DIRNAME, '[Test] dir\\file.txt'), destDir));
+    assert.doesNotThrow(() => tl.cp(path.join(srcDir, 'file.txt'), destDir));
     assert.ok(fs.existsSync(path.join(destDir, 'file.txt')));
     assert.equal(fs.readFileSync(path.join(destDir, 'file.txt'), 'utf8'), 'content');
 

--- a/node/test/cp.ts
+++ b/node/test/cp.ts
@@ -339,6 +339,45 @@ describe('cp cases', () => {
     done();
   });
 
+  it('cp falls back to literal copy when glob pattern returns no results', (done) => {
+    const srcDir = path.resolve(DIRNAME, '[Test] dir');
+    const destDir = path.resolve(DIRNAME, 'dest');
+    tl.mkdirP(srcDir);
+    tl.mkdirP(destDir);
+    fs.writeFileSync(path.join(srcDir, 'file.txt'), 'content');
+
+    assert.doesNotThrow(() => tl.cp(path.join(DIRNAME, '[Test] dir\\file.txt'), destDir));
+    assert.ok(fs.existsSync(path.join(destDir, 'file.txt')));
+    assert.equal(fs.readFileSync(path.join(destDir, 'file.txt'), 'utf8'), 'content');
+
+    tl.rmRF(srcDir);
+    tl.rmRF(destDir);
+    done();
+  });
+
+  it('cp with recursive full-path glob pattern', (done) => {
+    const nestedRoot = path.join(DIRNAME, 'src');
+    const nestedDirOne = path.join(nestedRoot, 'one');
+    const nestedDirTwo = path.join(nestedRoot, 'two', 'deep');
+    const ignoredDir = path.join(nestedRoot, 'skip');
+
+    tl.mkdirP(nestedDirOne);
+    tl.mkdirP(nestedDirTwo);
+    tl.mkdirP(ignoredDir);
+
+    fs.writeFileSync(path.join(nestedDirOne, 'file-one.txt'), 'nested-one');
+    fs.writeFileSync(path.join(nestedDirTwo, 'file-two.txt'), 'nested-two');
+    fs.writeFileSync(path.join(ignoredDir, 'other.log'), 'ignored');
+    const pattern = path.join(nestedRoot, '**', '*.txt');
+    assert.doesNotThrow(() => tl.cp(pattern, GLOB_DEST_DIR));
+    assert.ok(fs.existsSync(path.join(GLOB_DEST_DIR, 'file-one.txt')));
+    assert.ok(fs.existsSync(path.join(GLOB_DEST_DIR, 'file-two.txt')));
+    assert.ok(!fs.existsSync(path.join(GLOB_DEST_DIR, 'other.log')));
+
+    tl.rmRF(nestedRoot);
+    done();
+  });
+
   it('Handles non-normalized paths', (done) => {
     tl.mkdirP('dirC');
     fs.writeFileSync(path.join('dirC', 'file.txt'), 'abc');


### PR DESCRIPTION
### Problem

 The `cp` function's glob handling has issues:

1. **Infinite recursion and broken full-path globs due to dirname/basename split**: The glob detection regex checked the entire source path for special characters like `@`, `[`, `]`, `*`, `?`, but expansion used only `path.basename(source)` via `findMatch(path.dirname(source), [path.basename(source)])`. This caused two problems:
   - For literal paths containing special characters in directory names (e.g. `dir@test/file.txt`, `[Test] dir/file.txt`), the path was misidentified as a glob pattern. Since only the basename was expanded, `findMatch` returned the same literal path, and `cp` recursed on it endlessly until stack overflow.
   - For real full-path globs like `src/**/*.txt` or `packages/*/dist/output.js`, the glob characters in directory segments were split into `path.dirname` which is supposed to be a literal root — so the pattern semantics were lost.

2. **Bare `!` and `#`**: Leading `!` is an exclude operator in `findMatch` that removes files from a prior include set. Since `cp` takes a single source — not a pattern list — there is no prior include set for `!` to act on. Leading `#` would cause `findMatch` to silently skip the source as a comment. Neither behavior is appropriate for `cp`.

### Changes

- Removed `^[#!]` from the glob detection regex. The extglob operator `!(...)` is still correctly detected via `[@+!]\(`.
- Changed `cp` to pass the **full source pattern** to `findMatch` instead of splitting it into `path.dirname`/`path.basename`. This preserves glob semantics across directory segments and eliminates the self-referencing recursion.
- Added `{ nonegate: true, nocomment: true }` when calling `findMatch` from `cp` to prevent leading `!` and `#` from being consumed by `findMatch`'s list-level pre-processing.
- Added a shell-style fallback: when glob expansion returns zero matches, `cp` falls through to treat the source as a literal path. This matches how the previous `shell.cp` (shelljs) behaved — try pattern expansion first, and if nothing matches, copy the original path literally.

### Tests added

- **`cp falls back to literal copy when glob pattern returns no results`**: Copies a file from a directory with `[` and `]` in its name without infinite recursion or failure, verifying the literal fallback path.
- **`cp with recursive full-path glob pattern`**: Uses a pattern like `src/**/*.txt` across a nested directory structure and verifies that only matching files are copied while non-matching files are excluded.

Related issue - https://github.com/microsoft/azure-pipelines-task-lib/issues/1166