### PR TITLE
Update network isolation mode

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,8 @@ resources:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    settings:
+      networkIsolationMode: Audit
     featureFlags:
       autoBaseline: false
     sdl:


### PR DESCRIPTION
The [publish step](https://dev.azure.com/mseng/PipelineTools/PipelineTools%20Team/_build/results?buildId=31623515&view=logs&j=626cfb5d-177f-5235-cdc4-b875650635f1&t=4846ee8d-f2ee-5400-61a9-fb55155ade68&l=73) in the task-lib pipeline is failing because CFSClean blocks outbound connections to registry.npmjs.org:

  FetchError: request to https://registry.npmjs.org/azure-pipelines-task-lib failed, reason: connect EPERM 192.0.2.89:443 - Local (0.0.0.0:0)

  Fix
   Added `networkIsolationMode: Audit` 