### PR TITLE
Replace vulnerable UUID package with internal Node.js crypto for key generation

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -14,8 +14,7 @@
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
+        "shelljs": "^0.10.0"
       },
       "devDependencies": {
         "@types/minimatch": "3.0.3",
@@ -1642,16 +1641,6 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
       "integrity": "sha1-+fY5ENFVNu4rLV3UZlOJcV6sXB4=",
       "license": "(WTFPL OR MIT)"
-    },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "5.2.11",
+  "version": "5.276.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "azure-pipelines-task-lib",
-      "version": "5.2.11",
+      "version": "5.276.0",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "5.2.11",
+  "version": "5.276.0",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",

--- a/node/package.json
+++ b/node/package.json
@@ -32,8 +32,7 @@
     "nodejs-file-downloader": "^4.11.1",
     "q": "^1.5.1",
     "semver": "^5.7.2",
-    "shelljs": "^0.10.0",
-    "uuid": "^3.0.1"
+    "shelljs": "^0.10.0"
   },
   "devDependencies": {
     "@types/minimatch": "3.0.3",

--- a/node/vault.ts
+++ b/node/vault.ts
@@ -3,7 +3,6 @@ import fs = require('fs');
 import path = require('path');
 import crypto = require('crypto');
 
-var uuidV4 = require('uuid/v4');
 var algorithm = "aes-256-ctr";
 var encryptEncoding: 'hex' = 'hex';
 var unencryptedEncoding: 'utf8' = 'utf8';
@@ -18,23 +17,22 @@ var unencryptedEncoding: 'utf8' = 'utf8';
 export class Vault {
     constructor(keyPath: string) {
         this._keyFile = path.join(keyPath, '.taskkey');
-        this._store = <{[key: string] : string}>{};
+        this._store = <{ [key: string]: string }>{};
         this.genKey();
     }
 
     private _keyFile: string;
-    private _store: { [key: string] : string };
+    private _store: { [key: string]: string };
 
-    public initialize(): void {
-
-    }
+    public initialize(): void { }
 
     public storeSecret(name: string, data: string): boolean {
         if (!name || name.length == 0) {
             return false;
         }
 
-        name = name.toLowerCase()
+        name = name.toLowerCase();
+
         if (!data || data.length == 0) {
             if (this._store.hasOwnProperty(name)) {
                 delete this._store[name];
@@ -56,7 +54,7 @@ export class Vault {
 
     public retrieveSecret(name: string): string | undefined {
         var secret: string | undefined;
-        name = (name || '').toLowerCase()
+        name = (name || '').toLowerCase();
 
         if (this._store.hasOwnProperty(name)) {
             var key = this.getKey();
@@ -75,14 +73,13 @@ export class Vault {
         return secret;
     }
 
-    private getKey()
-    {
+    private getKey() {
         var key = fs.readFileSync(this._keyFile).toString('utf8');
         // Key needs to be hashed to correct length to match algorithm (aes-256-ctr)
         return crypto.createHash('sha256').update(key).digest();
     }
 
     private genKey(): void {
-        fs.writeFileSync(this._keyFile, uuidV4(), {encoding: 'utf8'});
+        fs.writeFileSync(this._keyFile, crypto.randomUUID(), { encoding: 'utf8' });
     }
 }


### PR DESCRIPTION
 **Summary**

 Replaces the deprecated and vulnerable **uuid** package with Node.js's built-in `crypto.randomUUID()` for generating the Vault encryption key.
This removes a third-party dependency and sources the key from a cryptographically secure generator.

 **What changed**

 •  **node/vault.ts**: Removed `require('uuid/v4').genKey()` now calls the already-imported `crypto.randomUUID()` to produce the **.taskkey** value. Minor style cleanup (semicolons, brace formatting).
 •  **node/package.json** and **node/package-lock.json**: Dropped the **uuid^3.0.1** dependency.

 **Why**

  **uuid@3.4.0** is deprecated and vulnerable - older versions may fall back to Math.random(),  which is not cryptographically secure (details). Because the Vault key seeds AES-256-CTR encryption of secrets, it should come from a CSPRNG. `crypto.randomUUID()` is built into Node.js, cryptographically strong, and eliminates the external package.

 **Testing**

 • Existing Vault unit tests:  node/test/vaulttests.ts .
 • Build and run the Node test suite.

 **Risks and rollback**

 •  **crypto.randomUUID()** requires Node.js ≥ **14.17** - confirm all supported runtimes meet this minimum.
 • The key is hashed with **SHA-256** before use and regenerated each run, so the change in key value/format is backward compatible.
 • Rollback: revert the single commit to restore the **uuid** dependency.