### PR TITLE
Fix cp recursion error

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "5.276.0",
+  "version": "5.277.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "azure-pipelines-task-lib",
-      "version": "5.276.0",
+      "version": "5.277.0",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "5.276.0",
+  "version": "5.277.0",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",

--- a/node/task.ts
+++ b/node/task.ts
@@ -1235,13 +1235,16 @@ export function cp(sourceOrOptions: unknown, destinationOrSource: string, option
         const isPattern = /[*?{\[]/.test(source) || /[@+!]\(/.test(source);
         if (isPattern) {
             const defaultRoot = getVariable('system.defaultWorkingDirectory') || process.cwd();
-            const sourcesToProcess = findMatch(defaultRoot, [source], undefined, <MatchOptions>{nonegate: true, nocomment: true});
-            if (sourcesToProcess.length > 0) {
-                for (const src of sourcesToProcess) {
-                    cp(src, destination, options as CopyOptionsVariants, continueOnError, retryCount);
-                }
+            const matches = findMatch(defaultRoot, [source], undefined, <MatchOptions>{nonegate: true, nocomment: true});
+            const resolvedMatches = matches.filter((src) => path.resolve(src) !== path.resolve(source));
+            for (const src of resolvedMatches) {
+                cp(src, destination, options as CopyOptionsVariants, continueOnError, retryCount);
+            }
+
+            if (matches.length > 0 && resolvedMatches.length === matches.length) {
                 return;
-            } else {
+            }
+            if (matches.length === 0) {
                 debug(`No matches found for the pattern: ${source}. Fallback to check for the literal path.`);
             }
         }

--- a/node/test/cp.ts
+++ b/node/test/cp.ts
@@ -302,7 +302,7 @@ describe('cp cases', () => {
   });
 
   it('cp with combined ? and [pattern] patterns', (done) => {
-    const pattern = path.join(GLOB_TEST_DIR, 'file[1-3].???');
+    const pattern = path.join(GLOB_TEST_DIR, 'file{1..3}.???');
     assert.doesNotThrow(() => tl.cp(pattern, GLOB_DEST_DIR));
 
     assert.ok(fs.existsSync(path.join(GLOB_DEST_DIR, 'file1.txt')));
@@ -341,6 +341,22 @@ describe('cp cases', () => {
 
   it('cp falls back to literal copy when glob pattern returns no results', (done) => {
     const srcDir = path.resolve(DIRNAME, '[Test] dir');
+    const destDir = path.resolve(DIRNAME, 'dest');
+    tl.mkdirP(srcDir);
+    tl.mkdirP(destDir);
+    fs.writeFileSync(path.join(srcDir, 'file.txt'), 'content');
+
+    assert.doesNotThrow(() => tl.cp(path.join(srcDir, 'file.txt'), destDir));
+    assert.ok(fs.existsSync(path.join(destDir, 'file.txt')));
+    assert.equal(fs.readFileSync(path.join(destDir, 'file.txt'), 'utf8'), 'content');
+
+    tl.rmRF(srcDir);
+    tl.rmRF(destDir);
+    done();
+  });
+
+  it(' handles a source path that findMatch returns identical to the input', (done) => {
+    const srcDir = path.resolve(DIRNAME, '{Testdir}');
     const destDir = path.resolve(DIRNAME, 'dest');
     tl.mkdirP(srcDir);
     tl.mkdirP(destDir);


### PR DESCRIPTION
### Problem

`tl.cp()` throws `RangeError: Maximum call stack size exceeded` and hangs in infinite recursion when copying a **literal file whose name contains glob-special characters** — most commonly braces, e.g. a GUID filename like `{00000000-0000-0000-0000-000000000000}_back.gif`.

This is a regression surfaced by [azure-pipelines-tasks#22308](https://github.com/microsoft/azure-pipelines-tasks/issues/22308) (`IISWebAppDeploymentOnMachineGroup@0` broke in `0.275.0`, last good `0.270.0`). Any classic deployment copying files of the form `path\{...}_foo.bar` fails.

### Root cause

`cp` flags a source as a glob when it contains `* ? { [` (or an extglob `@( +( !(`), then calls `findMatch` and **recurses `cp()` on every match**. For a source that isn't a *real* pattern:

- A comma/range-less brace `{guid}` (and other "detected but inert" characters like `[]`, `file[1.txt`, `@(abc`) is escaped to a **literal** by minimatch, so `findMatch` returns the **source path unchanged**.
- That single result equals the source, so `cp(src)` re-enters with the identical path, re-detects the "pattern", and matches itself again — recursing until the stack overflows.

The previous(https://github.com/microsoft/azure-pipelines-task-lib/pull/1177) literal-path fallback only triggered when `findMatch` returned **zero** matches; the self-match returns **one** (itself), so it slipped past.

### Changes (`node/task.ts`)

- Filter out any match that resolves back to the source itself (`resolvedMatches`), and recurse only on the remaining, genuinely-expanded paths.
- Return early only for a **pure glob** (had matches, none equal to the source). Otherwise fall through to copy `source` as a **literal path** — this breaks the recursion while still copying every match, including the self-match.
- This also correctly handles the multi-match case (e.g. on Linux, `cp('dir/*.txt', dest)` where a file is literally named `*.txt`): the other files are copied via recursion and the self-named file is copied literally, so nothing is dropped.

### Tests added (`node/test/cp.ts`)

- **`handles a source path that findMatch returns identical to the input`** — copies `file.txt` from a directory named `{Testdir}` (braces in the path make `findMatch` return the source verbatim); asserts it copies without infinite recursion.
- Updated the combined-pattern test to exercise brace-range expansion (`file{1..3}.???`).

### Related issue

- https://github.com/microsoft/azure-pipelines-tasks/issues/22308

*(Also bumps `node/package.json` `5.276.0` → `5.277.0`.)*