### PR TITLE
Update vulnerability adm zip to v0.6.0

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "5.277.0",
+  "version": "5.278.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "azure-pipelines-task-lib",
-      "version": "5.277.0",
+      "version": "5.278.0",
       "license": "MIT",
       "dependencies": {
-        "adm-zip": "^0.5.10",
+        "adm-zip": "^0.6.0",
         "minimatch": "^3.1.5",
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
@@ -23,31 +23,8 @@
         "@types/q": "^1.5.4",
         "@types/semver": "^7.3.4",
         "@types/shelljs": "^0.8.17",
-        "mocha": "^11.7.5",
+        "mocha": "11.7.5",
         "typescript": "^4.9.5"
-      }
-    },
-    "node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-      "integrity": "sha1-MIHa28NGBmG3UedZHX+upd853Sk=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-      "integrity": "sha1-Sz2rq32OdaQpQUqWvWe/TB0T4PM=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -161,12 +138,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.15",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.15.tgz",
-      "integrity": "sha1-wsmz1POxyRHnKyOU6E/ZG8yB4I4=",
+      "version": "0.6.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha1-u8XGwzN1XpZ6Bt2YdH9DHh1To88=",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {
@@ -224,9 +201,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "version": "1.1.16",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha1-cj06MMBVjCJavJ/Eeac+FOJsPC8=",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -600,9 +577,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha1-f4FcDNpCScdP8J6V75fCO1/QOZs=",
+      "version": "1.16.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha1-KEdKFZ07nRHvYgUKFO1g5N9tYbw=",
       "funding": [
         {
           "type": "individual",
@@ -694,17 +671,40 @@
         "node": ">= 6"
       }
     },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha1-v7EGYv7tgZaixi58aOF3IMJ0F5o=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha1-Gw5GlltHna1lr3N7SgJ5CgVJgzc=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "10.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-10.1.1.tgz",
-      "integrity": "sha1-5uYbmwwdyrEWtafRRY6LaunnOlU=",
+      "version": "10.2.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha1-vUhoegvjjtKWE5kQVgD4MglYYdE=",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -860,10 +860,20 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha1-wftl+PUBeQHN0slRhkuhhFihBgI=",
+      "version": "4.3.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha1-0ZAFcqf3zwtfVAyDZz5gutNDZZI=",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -1033,9 +1043,9 @@
       }
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha1-VPxTI3phPYVMe9N0Y6rRffhyFOc=",
+      "version": "2.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha1-C7oicf631Fiw0xrRNiWqpHVEMeI=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1087,13 +1097,13 @@
       "license": "ISC"
     },
     "node_modules/mocha/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha1-10+d1rV9g9jpjPuCEzsDl4vJKeU=",
+      "version": "9.0.9",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha1-mwy5/LeAh/b9fqur4lEcTT1gV04=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -1254,9 +1264,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI=",
+      "version": "2.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha1-WpQpFeJrNy3A8OZ1MUmhbmscVgE=",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "5.277.0",
+  "version": "5.278.0",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/Microsoft/azure-pipelines-task-lib",
   "dependencies": {
-    "adm-zip": "^0.5.10",
+    "adm-zip": "^0.6.0",
     "minimatch": "^3.1.5",
     "nodejs-file-downloader": "^4.11.1",
     "q": "^1.5.1",
@@ -41,7 +41,7 @@
     "@types/q": "^1.5.4",
     "@types/semver": "^7.3.4",
     "@types/shelljs": "^0.8.17",
-    "mocha": "^11.7.5",
+    "mocha": "11.7.5",
     "typescript": "^4.9.5"
   }
 }


### PR DESCRIPTION
## Summary

Resolves an open high-severity `adm-zip` vulnerability

## What changed

**Dependency updates** (`node/package.json`, `node/package-lock.json`)
- `adm-zip`: `^0.5.10` → `^0.6.0`

## Why

- `adm-zip < 0.6.0` has an open high-severity advisory — a crafted ZIP file can trigger a ~4GB memory allocation (denial of service): [GHSA-xcpc-8h2w-3j85](https://github.com/advisories/GHSA-xcpc-8h2w-3j85) / CVE-2026-39244.

## Testing

- `npm run build` succeeds
- `npm test` succeeds
