### PR TITLE
fix: update mocha version and refactor test functions

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -23,7 +23,7 @@
         "@types/q": "^1.5.4",
         "@types/semver": "^7.3.4",
         "@types/shelljs": "^0.8.17",
-        "mocha": "11.7.5",
+        "mocha": "^11.7.6",
         "typescript": "^4.9.5"
       }
     },
@@ -1006,9 +1006,9 @@
       }
     },
     "node_modules/mocha": {
-      "version": "11.7.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mocha/-/mocha-11.7.5.tgz",
-      "integrity": "sha1-WPW7+l4CEc5+XuYSgQfO/CUVpic=",
+      "version": "11.7.6",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mocha/-/mocha-11.7.6.tgz",
+      "integrity": "sha1-674imJ0Ey7lCSjYwcyBHZiTEGjM=",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/node/package.json
+++ b/node/package.json
@@ -41,7 +41,7 @@
     "@types/q": "^1.5.4",
     "@types/semver": "^7.3.4",
     "@types/shelljs": "^0.8.17",
-    "mocha": "11.7.5",
+    "mocha": "^11.7.6",
     "typescript": "^4.9.5"
   }
 }

--- a/node/test/dirtests.ts
+++ b/node/test/dirtests.ts
@@ -27,7 +27,7 @@ describe('Dir Operation Tests', function () {
 
     // this test verifies the expected version of node is being used to run the tests.
     // 5.10.1 is what ships in the 1.x and 2.x agent.
-    it('is expected version', (done) => {
+    it('is expected version', function (done) {
         this.timeout(1000);
 
         console.log('node version: ' + process.version);
@@ -562,7 +562,7 @@ describe('Dir Operation Tests', function () {
     }
 
     // find tests
-    it('returns hidden files with find', (done) => {
+    it('returns hidden files with find', function (done) {
         this.timeout(3000);
 
         // create the following layout:
@@ -588,7 +588,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('returns depth first find', (done) => {
+    it('returns depth first find', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -621,7 +621,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('returns empty when not exists', (done) => {
+    it('returns empty when not exists', function (done) {
         this.timeout(1000);
 
         let itemPaths: string[] = tl.find(path.join(testutil.getTestTemp(), 'nosuch'));
@@ -630,7 +630,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('does not follow specified symlink', (done) => {
+    it('does not follow specified symlink', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -649,7 +649,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('follows specified symlink when -H', (done) => {
+    it('follows specified symlink when -H', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -671,7 +671,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('follows specified symlink when -L', (done) => {
+    it('follows specified symlink when -L', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -693,7 +693,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('does not follow symlink', (done) => {
+    it('does not follow symlink', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -716,7 +716,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('does not follow symlink when -H', (done) => {
+    it('does not follow symlink when -H', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -741,7 +741,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('follows symlink when -L', (done) => {
+    it('follows symlink when -L', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -767,7 +767,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('allows broken symlink', (done) => {
+    it('allows broken symlink', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -794,7 +794,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('allows specified broken symlink', (done) => {
+    it('allows specified broken symlink', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -812,7 +812,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('allows nested broken symlink when -H', (done) => {
+    it('allows nested broken symlink when -H', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -841,7 +841,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('allows specified broken symlink with -H', (done) => {
+    it('allows specified broken symlink with -H', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -862,7 +862,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('does not allow specified broken symlink when only -H', (done) => {
+    it('does not allow specified broken symlink when only -H', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -887,7 +887,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('does not allow broken symlink when only -L', (done) => {
+    it('does not allow broken symlink when only -L', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -910,7 +910,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('does not allow specied broken symlink when only -L', (done) => {
+    it('does not allow specied broken symlink when only -L', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -935,7 +935,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('allow broken symlink with -L', (done) => {
+    it('allow broken symlink with -L', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -966,7 +966,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('allow specified broken symlink with -L', (done) => {
+    it('allow specified broken symlink with -L', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -988,7 +988,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('detects cycle', (done) => {
+    it('detects cycle', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -1009,7 +1009,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('detects cycle starting from symlink', (done) => {
+    it('detects cycle starting from symlink', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -1030,7 +1030,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('detects deep cycle starting from middle', (done) => {
+    it('detects deep cycle starting from middle', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -1069,7 +1069,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('default options', (done) => {
+    it('default options', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -1099,7 +1099,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('default options do not allow broken symlinks', (done) => {
+    it('default options do not allow broken symlinks', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -1121,7 +1121,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('empty find path returns empty array', (done) => {
+    it('empty find path returns empty array', function (done) {
         this.timeout(1000);
 
         let actual: string[] = tl.find('');
@@ -1131,7 +1131,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('normalizes find path', (done) => {
+    it('normalizes find path', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -1220,7 +1220,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('fails if mkdirP with conflicting file path', (done) => {
+    it('fails if mkdirP with conflicting file path', function (done) {
         this.timeout(1000);
 
         let testPath = path.join(testutil.getTestTemp(), 'mkdirP_conflicting_file_path');
@@ -1238,7 +1238,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('fails if mkdirP with conflicting parent file path', (done) => {
+    it('fails if mkdirP with conflicting parent file path', function (done) {
         this.timeout(1000);
 
         let testPath = path.join(testutil.getTestTemp(), 'mkdirP_conflicting_parent_file_path', 'dir');
@@ -1256,7 +1256,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('no-ops if mkdirP directory exists', (done) => {
+    it('no-ops if mkdirP directory exists', function (done) {
         this.timeout(1000);
 
         let testPath = path.join(testutil.getTestTemp(), 'mkdirP_dir_exists');
@@ -1268,7 +1268,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('no-ops if mkdirP with symlink directory', (done) => {
+    it('no-ops if mkdirP with symlink directory', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -1294,7 +1294,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('no-ops if mkdirP with parent symlink directory', (done) => {
+    it('no-ops if mkdirP with parent symlink directory', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -1320,7 +1320,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('breaks if mkdirP loop out of control', (done) => {
+    it('breaks if mkdirP loop out of control', function (done) {
         this.timeout(1000);
 
         let testPath = path.join(testutil.getTestTemp(), 'mkdirP_failsafe', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10');
@@ -1419,7 +1419,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('removes file with rmRF', (done) => {
+    it('removes file with rmRF', function (done) {
         this.timeout(1000);
 
         let file: string = path.join(testutil.getTestTemp(), 'rmRF_file');
@@ -1431,7 +1431,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('removes hidden folder with rmRF', (done) => {
+    it('removes hidden folder with rmRF', function (done) {
         this.timeout(1000);
 
         let directory: string = path.join(testutil.getTestTemp(), '.rmRF_directory');
@@ -1443,7 +1443,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('removes hidden file with rmRF', (done) => {
+    it('removes hidden file with rmRF', function (done) {
         this.timeout(1000);
 
         let file: string = path.join(testutil.getTestTemp(), '.rmRF_file');
@@ -1455,7 +1455,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('removes symlink folder with rmRF', (done) => {
+    it('removes symlink folder with rmRF', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -1481,7 +1481,7 @@ describe('Dir Operation Tests', function () {
 
     // creating a symlink to a file on Windows requires elevated
     if (os.platform() != 'win32') {
-        it('removes symlink file with rmRF', (done) => {
+        it('removes symlink file with rmRF', function (done) {
             this.timeout(1000);
 
             // create the following layout:
@@ -1501,7 +1501,7 @@ describe('Dir Operation Tests', function () {
 
             done();
         });
-        it('removes symlink file with missing source using rmRF', (done) => {
+        it('removes symlink file with missing source using rmRF', function (done) {
             this.timeout(1000);
 
             // create the following layout:
@@ -1533,7 +1533,7 @@ describe('Dir Operation Tests', function () {
             done();
         });
 
-        it('removes symlink level 2 file with rmRF', (done) => {
+        it('removes symlink level 2 file with rmRF', function (done) {
             this.timeout(1000);
 
             // create the following layout:
@@ -1558,7 +1558,7 @@ describe('Dir Operation Tests', function () {
             done();
         });
 
-        it('removes nested symlink file with rmRF', (done) => {
+        it('removes nested symlink file with rmRF', function (done) {
             this.timeout(1000);
 
             // create the following layout:
@@ -1586,7 +1586,7 @@ describe('Dir Operation Tests', function () {
             done();
         });
 
-        it('removes deeply nested symlink file with rmRF', (done) => {
+        it('removes deeply nested symlink file with rmRF', function (done) {
             this.timeout(1000);
 
             // create the following layout:
@@ -1617,7 +1617,7 @@ describe('Dir Operation Tests', function () {
         });
     }
 
-    it('removes symlink folder with missing source using rmRF', (done) => {
+    it('removes symlink folder with missing source using rmRF', function (done) {
         this.timeout(1000);
     
         // create the following layout:
@@ -1652,7 +1652,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('removes symlink level 2 folder with rmRF', (done) => {
+    it('removes symlink level 2 folder with rmRF', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -1684,7 +1684,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('removes nested symlink folder with rmRF', (done) => {
+    it('removes nested symlink folder with rmRF', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -1712,7 +1712,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('removes deeply nested symlink folder with rmRF', (done) => {
+    it('removes deeply nested symlink folder with rmRF', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -1742,7 +1742,7 @@ describe('Dir Operation Tests', function () {
         done();
     });
 
-    it('removes hidden file with rmRF', (done) => {
+    it('removes hidden file with rmRF', function (done) {
         this.timeout(1000);
 
         let file: string = path.join(testutil.getTestTemp(), '.rmRF_file');
@@ -1829,7 +1829,7 @@ describe('Dir Operation Tests', function () {
     });
 
     // cp tests
-    it('copies file using -f', (done) => {
+    it('copies file using -f', function (done) {
         this.timeout(1000);
 
         let root: string = path.join(testutil.getTestTemp(), 'cp_with_-f');

--- a/node/test/filtertests.ts
+++ b/node/test/filtertests.ts
@@ -20,7 +20,7 @@ describe('Filter Tests', function () {
     after(function () {
     });
 
-    it('applies default option nobrace true', (done) => {
+    it('applies default option nobrace true', function (done) {
         this.timeout(1000);
 
         let list = [
@@ -38,7 +38,7 @@ describe('Filter Tests', function () {
         done();
     });
 
-    it('applies default option noglobstar false', (done) => {
+    it('applies default option noglobstar false', function (done) {
         this.timeout(1000);
 
         let list = [
@@ -58,7 +58,7 @@ describe('Filter Tests', function () {
         done();
     });
 
-    it('applies default option dot true', (done) => {
+    it('applies default option dot true', function (done) {
         this.timeout(1000);
 
         let list = [
@@ -75,7 +75,7 @@ describe('Filter Tests', function () {
         done();
     });
 
-    it('applies default option noext false', (done) => {
+    it('applies default option noext false', function (done) {
         this.timeout(1000);
 
         let list = [
@@ -94,7 +94,7 @@ describe('Filter Tests', function () {
         done();
     });
 
-    it('applies default option nocase based on platform', (done) => {
+    it('applies default option nocase based on platform', function (done) {
         this.timeout(1000);
 
         let list = [
@@ -114,7 +114,7 @@ describe('Filter Tests', function () {
         done();
     });
 
-    it('applies default option matchBase false', (done) => {
+    it('applies default option matchBase false', function (done) {
         this.timeout(1000);
 
         let list = [
@@ -131,7 +131,7 @@ describe('Filter Tests', function () {
         done();
     });
 
-    it('applies default option nocomment false', (done) => {
+    it('applies default option nocomment false', function (done) {
         this.timeout(1000);
 
         let list = [
@@ -145,7 +145,7 @@ describe('Filter Tests', function () {
         done();
     });
 
-    it('applies default option nonegate false', (done) => {
+    it('applies default option nonegate false', function (done) {
         this.timeout(1000);
 
         let list = [
@@ -162,7 +162,7 @@ describe('Filter Tests', function () {
         done();
     });
 
-    it('supports custom options', (done) => {
+    it('supports custom options', function (done) {
         this.timeout(1000);
 
         let list = [

--- a/node/test/findmatchtests.ts
+++ b/node/test/findmatchtests.ts
@@ -23,7 +23,7 @@ describe('Find and Match Tests', function () {
     after(function () {
     });
 
-    it('single pattern', (done) => {
+    it('single pattern', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -46,7 +46,7 @@ describe('Find and Match Tests', function () {
         done();
     });
 
-    it('aggregates matches', (done) => {
+    it('aggregates matches', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -73,7 +73,7 @@ describe('Find and Match Tests', function () {
         done();
     });
 
-    it('supports path not found', (done) => {
+    it('supports path not found', function (done) {
         this.timeout(1000);
 
         let root: string = path.join(testutil.getTestTemp(), 'find-and-match_supports-path-not-found');
@@ -89,7 +89,7 @@ describe('Find and Match Tests', function () {
         done();
     });
 
-    it('does not duplicate matches', (done) => {
+    it('does not duplicate matches', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -121,7 +121,7 @@ describe('Find and Match Tests', function () {
         done();
     });
 
-    it('supports interleaved exclude patterns', (done) => {
+    it('supports interleaved exclude patterns', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -168,7 +168,7 @@ describe('Find and Match Tests', function () {
         done();
     });
 
-    it('applies default match options', (done) => {
+    it('applies default match options', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -252,7 +252,7 @@ describe('Find and Match Tests', function () {
         done();
     });
 
-    it('trims patterns', (done) => {
+    it('trims patterns', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -274,7 +274,7 @@ describe('Find and Match Tests', function () {
         done();
     });
 
-    it('skips empty patterns', (done) => {
+    it('skips empty patterns', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -298,7 +298,7 @@ describe('Find and Match Tests', function () {
         done();
     });
 
-    it('supports nocomment true', (done) => {
+    it('supports nocomment true', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -320,7 +320,7 @@ describe('Find and Match Tests', function () {
         done();
     });
 
-    it('supports nobrace false', (done) => {
+    it('supports nobrace false', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -345,7 +345,7 @@ describe('Find and Match Tests', function () {
         done();
     });
 
-    it('brace escaping platform-specific', (done) => {
+    it('brace escaping platform-specific', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -380,7 +380,7 @@ describe('Find and Match Tests', function () {
     });
 
 
-    it('supports nonegate true', (done) => {
+    it('supports nonegate true', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -402,7 +402,7 @@ describe('Find and Match Tests', function () {
         done();
     });
 
-    it('supports flipNegate true', (done) => {
+    it('supports flipNegate true', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -424,7 +424,7 @@ describe('Find and Match Tests', function () {
         done();
     });
 
-    it('supports matchBase include patterns', (done) => {
+    it('supports matchBase include patterns', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -457,7 +457,7 @@ describe('Find and Match Tests', function () {
         done();
     });
 
-    it('supports matchBase include patterns with glob', (done) => {
+    it('supports matchBase include patterns with glob', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -490,7 +490,7 @@ describe('Find and Match Tests', function () {
         done();
     });
 
-    it('supports matchBase exlude pattern', (done) => {
+    it('supports matchBase exlude pattern', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -527,7 +527,7 @@ describe('Find and Match Tests', function () {
         done();
     });
 
-    it('counts leading negate markers', (done) => {
+    it('counts leading negate markers', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -564,7 +564,7 @@ describe('Find and Match Tests', function () {
         done();
     });
 
-    it('trims whitespace after trimming negate markers', (done) => {
+    it('trims whitespace after trimming negate markers', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -587,7 +587,7 @@ describe('Find and Match Tests', function () {
         done();
     });
 
-    it('evaluates comments before expanding braces', (done) => {
+    it('evaluates comments before expanding braces', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -616,7 +616,7 @@ describe('Find and Match Tests', function () {
         done();
     });
 
-    it('evaluates negation before expanding braces', (done) => {
+    it('evaluates negation before expanding braces', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -641,7 +641,7 @@ describe('Find and Match Tests', function () {
         done();
     });
 
-    it('evaluates comments before negation', (done) => {
+    it('evaluates comments before negation', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -667,7 +667,7 @@ describe('Find and Match Tests', function () {
         done();
     });
 
-    it('escapes default root when rooting patterns', (done) => {
+    it('escapes default root when rooting patterns', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -741,7 +741,7 @@ describe('Find and Match Tests', function () {
         done();
     });
 
-    it('applies default find options', (done) => {
+    it('applies default find options', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -763,7 +763,7 @@ describe('Find and Match Tests', function () {
         done();
     });
 
-    it('supports custom find options', (done) => {
+    it('supports custom find options', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -787,7 +787,7 @@ describe('Find and Match Tests', function () {
         done();
     });
 
-    it('default root falls back to System.DefaultWorkingDirectory', (done) => {
+    it('default root falls back to System.DefaultWorkingDirectory', function (done) {
         this.timeout(1000);
 
         let originalSystemDefaultWorkingDirectory = process.env['SYSTEM_DEFAULTWORKINGDIRECTORY'];
@@ -815,7 +815,7 @@ describe('Find and Match Tests', function () {
         done();
     });
 
-    it('default root falls back to cwd', (done) => {
+    it('default root falls back to cwd', function (done) {
         this.timeout(1000);
 
         let originalSystemDefaultWorkingDirectory = process.env['SYSTEM_DEFAULTWORKINGDIRECTORY'];
@@ -853,7 +853,7 @@ describe('Find and Match Tests', function () {
         }
     }
 
-    it('ensurePatternRooted()', (done) => {
+    it('ensurePatternRooted()', function (done) {
         this.timeout(1000);
 
         if (process.platform == 'win32') {
@@ -932,7 +932,7 @@ describe('Find and Match Tests', function () {
         assert.deepEqual(actual, expected);
     }
 
-    it('getFindInfoFromPattern()', (done) => {
+    it('getFindInfoFromPattern()', function (done) {
         this.timeout(1000);
 
         // basename

--- a/node/test/inputtests.ts
+++ b/node/test/inputtests.ts
@@ -133,7 +133,7 @@ describe('Input Tests', function () {
 
         done();
     })
-    it('gets a variable with special characters', (done) => {
+    it('gets a variable with special characters', function (done) {
         this.timeout(1000);
 
         let expected = 'Value of var with special chars';
@@ -156,7 +156,7 @@ describe('Input Tests', function () {
 
         done();
     })
-    it('sets a variable with special chars as an env var', (done) => {
+    it('sets a variable with special chars as an env var', function (done) {
         this.timeout(1000);
 
         let expected = 'Set value of var with special chars';

--- a/node/test/internalhelpertests.ts
+++ b/node/test/internalhelpertests.ts
@@ -59,7 +59,7 @@ describe('Internal Path Helper Tests', function () {
             `expected ensureRooted for input <${path}> to yield <${expected}>`);
     }
 
-    it('ensureRooted roots paths', (done) => {
+    it('ensureRooted roots paths', function (done) {
         this.timeout(1000);
 
         if (process.platform == 'win32') {
@@ -147,7 +147,7 @@ describe('Internal Path Helper Tests', function () {
             `expected getDirectoryName for input <${path}> to yield <${expected}>`);
     }
 
-    it('getDirectoryName interprets directory name from paths', (done) => {
+    it('getDirectoryName interprets directory name from paths', function (done) {
         this.timeout(1000);
 
         assertDirectoryName(null, '');
@@ -271,7 +271,7 @@ describe('Internal Path Helper Tests', function () {
             `expected isRooted for input <${path}> to yield <${expected}>`);
     }
 
-    it('isRooted detects root', (done) => {
+    it('isRooted detects root', function (done) {
         this.timeout(1000);
 
         if (process.platform == 'win32') {
@@ -362,7 +362,7 @@ describe('Internal Path Helper Tests', function () {
             `expected normalizeSeparators for input <${path}> to yield <${expected}>`);
     }
 
-    it('normalizeSeparators', (done) => {
+    it('normalizeSeparators', function (done) {
         this.timeout(1000);
 
         if (process.platform == 'win32') {

--- a/node/test/isuncpathtests.ts
+++ b/node/test/isuncpathtests.ts
@@ -19,7 +19,7 @@ describe('Is UNC-path Tests', function () {
     after(function () {
     });
 
-    it('checks if path is unc path', (done) => {
+    it('checks if path is unc path', function (done) {
         this.timeout(1000);
 
         const paths = [

--- a/node/test/legacyfindfilestests.ts
+++ b/node/test/legacyfindfilestests.ts
@@ -24,7 +24,7 @@ describe('Legacy Find Files Tests', function () {
     after(function () {
     });
 
-    it('supports directory name single char wildcard', (done) => {
+    it('supports directory name single char wildcard', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -55,7 +55,7 @@ describe('Legacy Find Files Tests', function () {
         done();
     });
 
-    it('supports directory name wildcard', (done) => {
+    it('supports directory name wildcard', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -86,7 +86,7 @@ describe('Legacy Find Files Tests', function () {
         done();
     });
 
-    it('supports exclude patterns', (done) => {
+    it('supports exclude patterns', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -127,7 +127,7 @@ describe('Legacy Find Files Tests', function () {
         done();
     });
 
-    it('supports file name single char wildcard', (done) => {
+    it('supports file name single char wildcard', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -154,7 +154,7 @@ describe('Legacy Find Files Tests', function () {
         done();
     });
 
-    it('supports file name wildcard', (done) => {
+    it('supports file name wildcard', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -181,7 +181,7 @@ describe('Legacy Find Files Tests', function () {
         done();
     });
 
-    it('supports globstar', (done) => {
+    it('supports globstar', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -214,7 +214,7 @@ describe('Legacy Find Files Tests', function () {
         done();
     });
 
-    it('supports include directories', (done) => {
+    it('supports include directories', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -243,7 +243,7 @@ describe('Legacy Find Files Tests', function () {
         done();
     });
 
-    it('supports include directories only', (done) => {
+    it('supports include directories only', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -270,7 +270,7 @@ describe('Legacy Find Files Tests', function () {
         done();
     });
 
-    it('supports inter-segment wildcard', (done) => {
+    it('supports inter-segment wildcard', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -310,7 +310,7 @@ describe('Legacy Find Files Tests', function () {
         done();
     });
 
-    it('unions matches', (done) => {
+    it('unions matches', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -338,7 +338,7 @@ describe('Legacy Find Files Tests', function () {
         done();
     });
 
-    it('has platform-specific case sensitivity', (done) => {
+    it('has platform-specific case sensitivity', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -373,7 +373,7 @@ describe('Legacy Find Files Tests', function () {
         done();
     });
 
-    it('supports literal ; in pattern', (done) => {
+    it('supports literal ; in pattern', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -395,7 +395,7 @@ describe('Legacy Find Files Tests', function () {
         done();
     });
 
-    it('supports literal ; in rootDirectory', (done) => {
+    it('supports literal ; in rootDirectory', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -419,7 +419,7 @@ describe('Legacy Find Files Tests', function () {
         done();
     });
 
-    it('supports pattern is ;', (done) => {
+    it('supports pattern is ;', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -441,7 +441,7 @@ describe('Legacy Find Files Tests', function () {
         done();
     });
 
-    it('does not support pattern with trailing slash', (done) => {
+    it('does not support pattern with trailing slash', function (done) {
         this.timeout(1000);
 
         let pattern = path.join(__dirname, 'hello', 'world') + '/';
@@ -455,7 +455,7 @@ describe('Legacy Find Files Tests', function () {
         }
     });
 
-    it('has platform-specific support for pattern with trailing backslash', (done) => {
+    it('has platform-specific support for pattern with trailing backslash', function (done) {
         this.timeout(1000);
 
         if (process.platform == 'win32') {
@@ -493,7 +493,7 @@ describe('Legacy Find Files Tests', function () {
         }
     });
 
-    it('follows symlink dirs', (done) => {
+    it('follows symlink dirs', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -528,7 +528,7 @@ describe('Legacy Find Files Tests', function () {
         done();
     });
 
-    it('supports alternate include syntax', (done) => {
+    it('supports alternate include syntax', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -556,7 +556,7 @@ describe('Legacy Find Files Tests', function () {
         done();
     });
 
-    it('appends root directory', (done) => {
+    it('appends root directory', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -584,7 +584,7 @@ describe('Legacy Find Files Tests', function () {
         done();
     });
 
-    it('supports hidden files', (done) => {
+    it('supports hidden files', function (done) {
         this.timeout(1000);
 
         // create the following layout:
@@ -611,7 +611,7 @@ describe('Legacy Find Files Tests', function () {
         done();
     });
 
-    it('supports hidden folders', (done) => {
+    it('supports hidden folders', function (done) {
         this.timeout(1000);
 
         // create the following layout:

--- a/node/test/matchtests.ts
+++ b/node/test/matchtests.ts
@@ -20,7 +20,7 @@ describe('Match Tests', function () {
     after(function () {
     });
 
-    it('single pattern', (done) => {
+    it('single pattern', function (done) {
         this.timeout(1000);
 
         let list: string[] = [
@@ -38,7 +38,7 @@ describe('Match Tests', function () {
         done();
     });
 
-    it('aggregates matches', (done) => {
+    it('aggregates matches', function (done) {
         this.timeout(1000);
 
         let list: string[] = [
@@ -59,7 +59,7 @@ describe('Match Tests', function () {
         done();
     });
 
-    it('does not duplicate matches', (done) => {
+    it('does not duplicate matches', function (done) {
         this.timeout(1000);
 
         let list: string[] = [
@@ -83,7 +83,7 @@ describe('Match Tests', function () {
         done();
     });
 
-    it('preserves order', (done) => {
+    it('preserves order', function (done) {
         this.timeout(1000);
 
         let list: string[] = [
@@ -112,7 +112,7 @@ describe('Match Tests', function () {
         done();
     });
 
-    it('supports interleaved exclude patterns', (done) => {
+    it('supports interleaved exclude patterns', function (done) {
         this.timeout(1000);
 
         let list: string[] = [
@@ -144,7 +144,7 @@ describe('Match Tests', function () {
         done();
     });
 
-    it('applies default options', (done) => {
+    it('applies default options', function (done) {
         this.timeout(1000);
 
         let list: string[] = [
@@ -200,7 +200,7 @@ describe('Match Tests', function () {
         done();
     });
 
-    it('trims patterns', (done) => {
+    it('trims patterns', function (done) {
         this.timeout(1000);
 
         let list: string[] = [
@@ -219,7 +219,7 @@ describe('Match Tests', function () {
         done();
     });
 
-    it('skips empty patterns', (done) => {
+    it('skips empty patterns', function (done) {
         this.timeout(1000);
 
         let list: string[] = [
@@ -241,7 +241,7 @@ describe('Match Tests', function () {
         done();
     });
 
-    it('supports nocomment true', (done) => {
+    it('supports nocomment true', function (done) {
         this.timeout(1000);
 
         let list: string[] = [
@@ -260,7 +260,7 @@ describe('Match Tests', function () {
         done();
     });
 
-    it('supports nonegate true', (done) => {
+    it('supports nonegate true', function (done) {
         this.timeout(1000);
 
         let list: string[] = [
@@ -279,7 +279,7 @@ describe('Match Tests', function () {
         done();
     });
 
-    it('supports flipNegate true', (done) => {
+    it('supports flipNegate true', function (done) {
         this.timeout(1000);
 
         let list: string[] = [
@@ -298,7 +298,7 @@ describe('Match Tests', function () {
         done();
     });
 
-    it('counts leading negate markers', (done) => {
+    it('counts leading negate markers', function (done) {
         this.timeout(1000);
 
         let list: string[] = [
@@ -327,7 +327,7 @@ describe('Match Tests', function () {
         done();
     });
 
-    it('trims whitespace after trimming negate markers', (done) => {
+    it('trims whitespace after trimming negate markers', function (done) {
         this.timeout(1000);
 
         let list: string[] = [
@@ -347,7 +347,7 @@ describe('Match Tests', function () {
         done();
     });
 
-    it('evaluates comments before negation', (done) => {
+    it('evaluates comments before negation', function (done) {
         this.timeout(1000);
 
         let list: string[] = [
@@ -369,7 +369,7 @@ describe('Match Tests', function () {
         done();
     });
 
-    it('applies pattern root for include patterns', (done) => {
+    it('applies pattern root for include patterns', function (done) {
         this.timeout(1000);
 
         let list: string[] = [
@@ -394,7 +394,7 @@ describe('Match Tests', function () {
         done();
     });
 
-    it('applies pattern root for exclude patterns', (done) => {
+    it('applies pattern root for exclude patterns', function (done) {
         this.timeout(1000);
 
         let list: string[] = [
@@ -421,7 +421,7 @@ describe('Match Tests', function () {
         done();
     });
 
-    it('does not apply pattern root for basename matchBase include patterns', (done) => {
+    it('does not apply pattern root for basename matchBase include patterns', function (done) {
         this.timeout(1000);
 
         let list: string[] = [
@@ -448,7 +448,7 @@ describe('Match Tests', function () {
         done();
     });
 
-    it('does not apply pattern root for basename matchBase exclude patterns', (done) => {
+    it('does not apply pattern root for basename matchBase exclude patterns', function (done) {
         this.timeout(1000);
 
         let list: string[] = [

--- a/node/test/mocktests.ts
+++ b/node/test/mocktests.ts
@@ -358,7 +358,7 @@ describe('Mock Tests', function () {
         await Promise.resolve()
     })
 
-    it('MockTest handles node tasks correctly by async call', async () => {
+    it('MockTest handles node tasks correctly by async call', async function () {
         this.timeout(30000);
         const runner = await (new mtm.MockTestRunner).LoadAsync(path.join(__dirname, 'fakeTasks', 'node16task', 'entry.js'));
         const nodePath = runner.nodePath;

--- a/node/test/retrytests.ts
+++ b/node/test/retrytests.ts
@@ -19,7 +19,7 @@ describe('Retry Tests', function () {
     after(function () {
     });
 
-    it('retries to execute a function', (done) => {
+    it('retries to execute a function', function (done) {
         this.timeout(1000);
 
         const testError = Error('Test Error');


### PR DESCRIPTION
- Updated mocha dependency from 11.7.5 to 11.7.6 in package.json and package-lock.json.
- Refactored test function syntax from arrow functions to regular functions in multiple test files for consistency and to avoid potential issues with `this` context.