### PR TITLE
Fix console color fallback handling for invalid host values

### DIFF
--- a/powershell/Tests/L0/Get-ConsoleColorOrDefault.FallsBackForInvalidColors.ps1
+++ b/powershell/Tests/L0/Get-ConsoleColorOrDefault.FallsBackForInvalidColors.ps1
@@ -1,0 +1,68 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\lib\Initialize-Test.ps1
+Invoke-VstsTaskScript -ScriptBlock {
+    $vstsModule = Get-Module -Name VstsTaskSdk
+
+    $variableSets = @(
+        # Valid ConsoleColor values are preserved.
+        @{
+            Value = [System.ConsoleColor]::Green
+            DefaultColor = [System.ConsoleColor]::Red
+            Expected = [System.ConsoleColor]::Green
+            Message = "A valid ConsoleColor value should be preserved."
+        }
+        @{
+            Value = [System.ConsoleColor]::Black
+            DefaultColor = [System.ConsoleColor]::Red
+            Expected = [System.ConsoleColor]::Black
+            Message = "The 'Black' ConsoleColor (underlying value 0) should be preserved."
+        }
+        # Null falls back to the default.
+        @{
+            Value = $null
+            DefaultColor = [System.ConsoleColor]::Red
+            Expected = [System.ConsoleColor]::Red
+            Message = "A null value should fall back to the default color."
+        }
+        # A non-ConsoleColor type falls back to the default.
+        @{
+            Value = 'NotAColor'
+            DefaultColor = [System.ConsoleColor]::Yellow
+            Expected = [System.ConsoleColor]::Yellow
+            Message = "A string value should fall back to the default color."
+        }
+        @{
+            Value = [int]-1
+            DefaultColor = [System.ConsoleColor]::Cyan
+            Expected = [System.ConsoleColor]::Cyan
+            Message = "An Int32 value should fall back to the default color."
+        }
+        # An out-of-range value typed as ConsoleColor falls back to the default.
+        # A C# host can return a ConsoleColor whose underlying value is undefined
+        # (for example -1); the previous '-isnot [System.ConsoleColor]' check treated
+        # these as valid and passed them to Write-Host, causing a failure.
+        @{
+            Value = [System.Enum]::ToObject([System.ConsoleColor], -1)
+            DefaultColor = [System.ConsoleColor]::DarkGray
+            Expected = [System.ConsoleColor]::DarkGray
+            Message = "An undefined negative ConsoleColor value should fall back to the default color."
+        }
+        @{
+            Value = [System.Enum]::ToObject([System.ConsoleColor], 99)
+            DefaultColor = [System.ConsoleColor]::Red
+            Expected = [System.ConsoleColor]::Red
+            Message = "An undefined out-of-range ConsoleColor value should fall back to the default color."
+        }
+    )
+
+    foreach ($variableSet in $variableSets) {
+        # Act.
+        $actual = & $vstsModule Get-ConsoleColorOrDefault -Value $variableSet.Value -DefaultColor $variableSet.DefaultColor
+
+        # Assert.
+        Assert-AreEqual $variableSet.Expected $actual $variableSet.Message
+    }
+}

--- a/powershell/VstsTaskSdk/LoggingCommandFunctions.ps1
+++ b/powershell/VstsTaskSdk/LoggingCommandFunctions.ps1
@@ -19,6 +19,22 @@ $IssueSources = @{
     TaskInternal = "TaskInternal"
 }
 
+function Get-ConsoleColorOrDefault {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        $Value,
+        [Parameter(Mandatory = $true)]
+        [System.ConsoleColor]$DefaultColor
+    )
+
+    if ($Value -is [System.ConsoleColor] -and [System.Enum]::IsDefined([System.ConsoleColor], $Value)) {
+        return $Value
+    }
+
+    return $DefaultColor
+}
+
 <#
 .SYNOPSIS
 See https://github.com/Microsoft/vsts-tasks/blob/master/docs/authoring/commands.md
@@ -584,19 +600,11 @@ function Write-LogIssue {
     }
 
     if ($Type -eq 'error') {
-        $foregroundColor = $host.PrivateData.ErrorForegroundColor
-        $backgroundColor = $host.PrivateData.ErrorBackgroundColor
-        if ($foregroundColor -isnot [System.ConsoleColor] -or $backgroundColor -isnot [System.ConsoleColor]) {
-            $foregroundColor = [System.ConsoleColor]::Red
-            $backgroundColor = [System.ConsoleColor]::Black
-        }
+        $foregroundColor = Get-ConsoleColorOrDefault -Value $host.PrivateData.ErrorForegroundColor -DefaultColor ([System.ConsoleColor]::Red)
+        $backgroundColor = Get-ConsoleColorOrDefault -Value $host.PrivateData.ErrorBackgroundColor -DefaultColor ([System.ConsoleColor]::Black)
     } else {
-        $foregroundColor = $host.PrivateData.WarningForegroundColor
-        $backgroundColor = $host.PrivateData.WarningBackgroundColor
-        if ($foregroundColor -isnot [System.ConsoleColor] -or $backgroundColor -isnot [System.ConsoleColor]) {
-            $foregroundColor = [System.ConsoleColor]::Yellow
-            $backgroundColor = [System.ConsoleColor]::Black
-        }
+        $foregroundColor = Get-ConsoleColorOrDefault -Value $host.PrivateData.WarningForegroundColor -DefaultColor ([System.ConsoleColor]::Yellow)
+        $backgroundColor = Get-ConsoleColorOrDefault -Value $host.PrivateData.WarningBackgroundColor -DefaultColor ([System.ConsoleColor]::Black)
     }
 
     Write-Host $command -ForegroundColor $foregroundColor -BackgroundColor $backgroundColor
@@ -615,19 +623,11 @@ function Write-TaskDebug_Internal {
     }
 
     if ($AsVerbose) {
-        $foregroundColor = $host.PrivateData.VerboseForegroundColor
-        $backgroundColor = $host.PrivateData.VerboseBackgroundColor
-        if ($foregroundColor -isnot [System.ConsoleColor] -or $backgroundColor -isnot [System.ConsoleColor]) {
-            $foregroundColor = [System.ConsoleColor]::Cyan
-            $backgroundColor = [System.ConsoleColor]::Black
-        }
+        $foregroundColor = Get-ConsoleColorOrDefault -Value $host.PrivateData.VerboseForegroundColor -DefaultColor ([System.ConsoleColor]::Cyan)
+        $backgroundColor = Get-ConsoleColorOrDefault -Value $host.PrivateData.VerboseBackgroundColor -DefaultColor ([System.ConsoleColor]::Black)
     } else {
-        $foregroundColor = $host.PrivateData.DebugForegroundColor
-        $backgroundColor = $host.PrivateData.DebugBackgroundColor
-        if ($foregroundColor -isnot [System.ConsoleColor] -or $backgroundColor -isnot [System.ConsoleColor]) {
-            $foregroundColor = [System.ConsoleColor]::DarkGray
-            $backgroundColor = [System.ConsoleColor]::Black
-        }
+        $foregroundColor = Get-ConsoleColorOrDefault -Value $host.PrivateData.DebugForegroundColor -DefaultColor ([System.ConsoleColor]::DarkGray)
+        $backgroundColor = Get-ConsoleColorOrDefault -Value $host.PrivateData.DebugBackgroundColor -DefaultColor ([System.ConsoleColor]::Black)
     }
 
     Write-Host -Object $command -ForegroundColor $foregroundColor -BackgroundColor $backgroundColor

--- a/powershell/package-lock.json
+++ b/powershell/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vsts-task-sdk",
-  "version": "0.21.3",
+  "version": "0.21.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vsts-task-sdk",
-      "version": "0.21.3",
+      "version": "0.21.4",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/powershell/package.json
+++ b/powershell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-task-sdk",
-  "version": "0.21.3",
+  "version": "0.21.4",
   "private": true,
   "scripts": {
     "build": "node make.js build",


### PR DESCRIPTION
# Description
Migrates the change from #1168 into this branch and bumps the PowerShell SDK version.

Adds a `Get-ConsoleColorOrDefault` helper that validates host-provided console color values and falls back to known defaults when the value is invalid. Both `Write-LogIssue` and `Write-TaskDebug_Internal` now use it for their foreground/background colors.

# Why?
Some Linux environments return invalid console color values (for example `-1`). Because a C# host can return a value that is typed as `[System.ConsoleColor]` but whose underlying number is undefined, the previous `-isnot [System.ConsoleColor]` check treated it as valid and passed it straight to `Write-Host`, failing task execution. The new helper also runs `[System.Enum]::IsDefined`, so undefined values fall back to the defaults and logging stays resilient across platforms.

# Changes
- Add `Get-ConsoleColorOrDefault` helper in `LoggingCommandFunctions.ps1` and use it in `Write-LogIssue` and `Write-TaskDebug_Internal`.
- Add L0 test `Get-ConsoleColorOrDefault.FallsBackForInvalidColors.ps1` covering valid colors, `$null`, non-`ConsoleColor` types, and undefined `ConsoleColor`-typed values (`-1`, `99`).
- Bump `vsts-task-sdk` version `0.21.3` → `0.21.4` (`package.json` + `package-lock.json`).

# Testing
`node make.js test` — 108 passing (includes the new test).

# Related
- Original PR: #1168
- https://github.com/microsoft/azure-pipelines-agent/pull/5530

Co-authored-by: MJECloud <mjecld@outlook.com>