### PR TITLE
Add ESRP-based npm release pipeline; make CI publish PR-only

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -1,0 +1,310 @@
+# =============================================================================
+# Release pipeline: publish azure-pipelines-task-lib to npmjs.org via ESRP
+# =============================================================================
+#
+# This pipeline builds, tests, packs, and RELEASES the npm package using the
+# ESRP Release (EsrpRelease) task instead of `npm publish`.
+#
+# HOW ESRP PUBLISHING WORKS (read before editing):
+#   * npm package publication is performed by the ESRP Release task, NOT by
+#     `npm publish`. ESRP is Microsoft's managed release service (adds signing,
+#     provenance, and an approval/notification workflow).
+#   * ESRP only publishes PRE-BUILT .tgz package files. It does NOT run
+#     `npm pack`. This pipeline runs `npm pack` (in the Package stage) and hands
+#     ESRP a folder of .tgz files; ESRP just distributes them to npmjs.org.
+#   * The npm dist-tag can be inferred by ESRP from the package's
+#     `publishConfig.tag` field in package.json. When it is not set, ESRP
+#     publishes under the default `latest` tag. (This package has no
+#     publishConfig, so releases go out as `latest`.)
+#
+# Stages:
+#   1. Build               - npm ci + npm run build + npm test; publish _build.
+#   2. Package             - npm pack -> stage .tgz as the 'npm-packages' artifact.
+#   3. PublishToNpmViaESRP - validate + hand the .tgz files to EsrpRelease@12.
+#
+# Trigger: MANUAL only. PR/CI validation lives in azure-pipelines.yml; this
+# pipeline never runs on PRs or automatically on push.
+#
+# Onboarding, required variables, and troubleshooting: see
+#   docs/esrp-npm-release.md
+# =============================================================================
+
+name: $(Date:yyyyMMdd)$(Rev:.r)
+
+trigger: none
+pr: none
+
+parameters:
+  # Safety switch: when true, the pipeline builds and packs the .tgz but SKIPS
+  # the ESRP publish stage entirely. Use it to validate a release candidate
+  # without pushing anything to npmjs.org.
+  - name: dryRun
+    displayName: 'Dry run (build + pack only; skip ESRP publish)'
+    type: boolean
+    default: false
+
+variables:
+  - name: nodeVersion
+    value: '16.13.0'
+
+  # ---------------------------------------------------------------------------
+  # ESRP wiring. The per-environment/identity values live in a variable group
+  # so nothing environment-specific is hard-coded here. Create the group in
+  # Pipelines > Library named 'esrp-npm-release' with these variables:
+  #   EsrpServiceConnection - name of the ESRP AzureRM (WIF/OIDC) service connection
+  #   EsrpKeyVault          - Key Vault holding the ESRP signing certificate
+  #   EsrpSignCert          - signing certificate name in that Key Vault
+  #   EsrpClientId          - client id of the ESRP-approved publisher identity
+  #   EsrpOwners            - comma-separated notification owner emails
+  #   EsrpApprovers         - comma-separated notification approver emails
+  # See docs/esrp-npm-release.md for how to obtain each value.
+  # ---------------------------------------------------------------------------
+  - group: esrp-npm-release
+
+  # Non-secret ESRP constants for public-npm (OSS) publishing. These are the
+  # well-known values for the ESRPRELPACMAN OSS publisher; override in the
+  # variable group only if your ESRP onboarding differs.
+  - name: EsrpMainPublisher
+    value: 'ESRPRELPACMAN'
+  - name: EsrpServiceEndpointUrl
+    value: 'https://api.esrp.microsoft.com'
+  # Tenant id for the ESRPRELPACMAN OSS publisher.
+  - name: EsrpDomainTenantId
+    value: '975f013f-7f24-47e8-a7d3-abc4752bf346'
+
+# The ESRP release runs in the mseng org and must be produced by the 1ES
+# Official pipeline template (same as the CI pipeline in azure-pipelines.yml).
+resources:
+  repositories:
+    - repository: 1ESPipelineTemplates
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    settings:
+      networkIsolationMode: Audit
+    sdl:
+      sourceAnalysisPool:
+        name: 1ES-ABTT-Shared-Pool
+        image: abtt-windows-2025
+        os: windows
+    stages:
+
+      # =======================================================================
+      # Stage 1: Build - install, compile, and test the package.
+      # Publishes the compiled output (node/_build) so the Package stage can
+      # pack it without rebuilding.
+      # =======================================================================
+      - stage: Build
+        displayName: Build and test
+        jobs:
+          - job: build
+            displayName: Build & test task-lib
+            pool:
+              name: 1ES-ABTT-Shared-Pool
+              image: abtt-ubuntu-2404
+              os: linux
+            templateContext:
+              outputs:
+                - output: pipelineArtifact
+                  displayName: 'Publish build output'
+                  targetPath: node/_build
+                  artifactName: build-output
+            steps:
+              - task: NodeTool@0
+                displayName: 'Use Node $(nodeVersion)'
+                inputs:
+                  versionSpec: $(nodeVersion)
+              # Authenticate to the internal npm feed referenced by .npmrc so
+              # `npm ci` can restore dependencies.
+              - task: NpmAuthenticate@0
+                displayName: 'Authenticate npm (.npmrc)'
+                inputs:
+                  workingFile: .npmrc
+              - script: npm ci
+                displayName: 'npm ci'
+                workingDirectory: node
+              - script: npm run build
+                displayName: 'npm run build'
+                workingDirectory: node
+              - script: npm test
+                displayName: 'npm test'
+                workingDirectory: node
+
+      # =======================================================================
+      # Stage 2: Package - produce the .tgz via `npm pack`.
+      # IMPORTANT: `npm pack` runs HERE, not in ESRP. ESRP only distributes the
+      # pre-built .tgz produced in this stage.
+      # =======================================================================
+      - stage: Package
+        displayName: Package (npm pack)
+        dependsOn: Build
+        jobs:
+          - job: pack
+            displayName: Create .tgz via npm pack
+            pool:
+              name: 1ES-ABTT-Shared-Pool
+              image: abtt-ubuntu-2404
+              os: linux
+            templateContext:
+              inputs:
+                # Download the compiled package output from the Build stage.
+                # This is the same directory the old pipeline ran `npm publish`
+                # from (node/_build): it contains package.json and the compiled
+                # .js/.d.ts, README, LICENSE, and Strings.
+                - input: pipelineArtifact
+                  artifactName: build-output
+                  targetPath: $(Pipeline.Workspace)/build-output
+              outputs:
+                - output: pipelineArtifact
+                  displayName: 'Publish npm package (.tgz)'
+                  targetPath: $(Build.ArtifactStagingDirectory)/npm-packages
+                  artifactName: npm-packages
+            steps:
+              - task: NodeTool@0
+                displayName: 'Use Node $(nodeVersion)'
+                inputs:
+                  versionSpec: $(nodeVersion)
+
+              # Guard: ESRP (and npm) cannot publish a package marked private.
+              # Fail early and clearly if package.json has "private": true.
+              - script: |
+                  node -e "const p=require('./package.json'); if (p.private===true){console.error('ERROR: package.json is marked private; refusing to publish.');process.exit(1);} console.log('OK: '+p.name+'@'+p.version+' is publishable (private is not true).');"
+                displayName: 'Validate package.json is publishable'
+                workingDirectory: $(Pipeline.Workspace)/build-output
+
+              # Produce the .tgz that ESRP will publish. ESRP does not pack; we
+              # stage the tarball into $(Build.ArtifactStagingDirectory)/npm-packages.
+              - script: |
+                  set -e
+                  mkdir -p "$(Build.ArtifactStagingDirectory)/npm-packages"
+                  npm pack --pack-destination "$(Build.ArtifactStagingDirectory)/npm-packages"
+                  echo "Packed contents:"
+                  ls -l "$(Build.ArtifactStagingDirectory)/npm-packages"
+                displayName: 'npm pack -> staging'
+                workingDirectory: $(Pipeline.Workspace)/build-output
+
+              # Fail the release if npm pack produced no package files.
+              - script: |
+                  count=$(ls -1 "$(Build.ArtifactStagingDirectory)/npm-packages"/*.tgz 2>/dev/null | wc -l)
+                  echo "Found $count .tgz file(s)."
+                  if [ "$count" -eq 0 ]; then
+                    echo "ERROR: npm pack produced no .tgz files; nothing to release."
+                    exit 1
+                  fi
+                displayName: 'Verify at least one .tgz exists'
+
+      # =======================================================================
+      # Stage 3: PublishToNpmViaESRP - hand the .tgz files to ESRP Release.
+      # Skipped entirely when the pipeline is queued with dryRun = true.
+      # =======================================================================
+      - ${{ if eq(parameters.dryRun, false) }}:
+        - stage: PublishToNpmViaESRP
+          displayName: Publish to npm via ESRP
+          dependsOn: Package
+          jobs:
+            - job: esrp
+              displayName: ESRP Release (npm)
+              pool:
+                name: 1ES-ABTT-Shared-Pool
+                image: abtt-windows-2025
+                os: windows
+              templateContext:
+                # 1ES: mark this as a production release job. Required for a job
+                # that publishes externally (via ESRP) so 1ES treats it as an
+                # official, isProduction release.
+                type: releaseJob
+                isProduction: true
+                inputs:
+                  - input: pipelineArtifact
+                    artifactName: npm-packages
+                    targetPath: $(Pipeline.Workspace)/npm-packages
+              steps:
+                - task: NodeTool@0
+                  displayName: 'Use Node $(nodeVersion)'
+                  inputs:
+                    versionSpec: $(nodeVersion)
+
+                # Authenticate to the internal ADO npm feed defined in .npmrc.
+                # This agent CANNOT reach the public npm registry, so the
+                # idempotency check below queries the ADO feed, never npmjs.
+                - task: NpmAuthenticate@0
+                  displayName: 'Authenticate to ADO npm feed (.npmrc)'
+                  inputs:
+                    workingFile: .npmrc
+
+                # Final guard before invoking ESRP: at least one .tgz must be
+                # present, otherwise fail the release rather than submit an
+                # empty ESRP request.
+                - pwsh: |
+                    $pkgs = @(Get-ChildItem "$(Pipeline.Workspace)/npm-packages" -Filter *.tgz -ErrorAction SilentlyContinue)
+                    Write-Host "Found $($pkgs.Count) .tgz file(s) to release:"
+                    $pkgs | ForEach-Object { Write-Host "  - $($_.Name)" }
+                    if ($pkgs.Count -eq 0) {
+                      Write-Error "No .tgz package files found; failing the release."
+                      exit 1
+                    }
+                  displayName: 'Verify packages exist before ESRP'
+
+                # Idempotency: skip ESRP if this exact name@version is already
+                # available. Preserves the old pipeline's tolerant
+                # "npm publish || true" behavior so a re-run for an already-
+                # published version is a no-op instead of a hard failure.
+                #
+                # IMPORTANT: this agent cannot reach the public npm registry, so
+                # the lookup goes through the internal ADO feed configured in the
+                # repo .npmrc (which proxies npmjs upstream). Running npm from the
+                # sources directory makes it pick up that .npmrc for both the
+                # registry URL and the auth token injected by NpmAuthenticate.
+                - pwsh: |
+                    $pkg = Get-ChildItem "$(Pipeline.Workspace)/npm-packages" -Filter *.tgz | Select-Object -First 1
+                    # Read name+version straight from the tarball's package.json.
+                    $json = tar -xOf $pkg.FullName package/package.json | ConvertFrom-Json
+                    $id = "$($json.name)@$($json.version)"
+                    Write-Host "Checking ADO feed for $id ..."
+                    $published = & npm view $id version 2>$null
+                    $exit = $LASTEXITCODE
+                    # npm view returns non-zero (E404) when the version is not
+                    # found; reset so this lookup does not fail the step.
+                    $global:LASTEXITCODE = 0
+                    if ($exit -eq 0 -and -not [string]::IsNullOrWhiteSpace($published)) {
+                      Write-Host "$id already available on the ADO feed; skipping ESRP release (idempotent re-run)."
+                      Write-Host "##vso[task.setvariable variable=npmAlreadyPublished]true"
+                    } else {
+                      Write-Host "$id not found on the ADO feed; will publish."
+                      Write-Host "##vso[task.setvariable variable=npmAlreadyPublished]false"
+                    }
+                  workingDirectory: $(Build.SourcesDirectory)
+                  displayName: 'Check whether version already published (ADO feed)'
+
+                # ESRP Release: performs the ACTUAL publish to npmjs.org.
+                #   intent=PackageDistribution + contenttype=npm -> npm publish
+                #   contentsource=Folder + folderlocation         -> folder of .tgz
+                #   waitforreleasecompletion=true                 -> block until done
+                # ESRP does NOT run npm pack; it distributes the .tgz staged above.
+                # The dist-tag is inferred from publishConfig.tag (default latest).
+                # NOTE: EsrpRelease@12 also accepts `productstate: <tag>` to pin the
+                # npm dist-tag explicitly (e.g. 'latest' or 'beta'); we intentionally
+                # omit it and let publishConfig.tag drive the tag per requirements.
+                - task: EsrpRelease@12
+                  displayName: 'Publish package to npm via ESRP'
+                  condition: and(succeeded(), ne(variables['npmAlreadyPublished'], 'true'))
+                  inputs:
+                    connectedservicename: '$(EsrpServiceConnection)'
+                    usemanagedidentity: true
+                    keyvaultname: '$(EsrpKeyVault)'
+                    signcertname: '$(EsrpSignCert)'
+                    clientid: '$(EsrpClientId)'
+                    intent: 'PackageDistribution'
+                    contenttype: 'npm'
+                    contentsource: 'Folder'
+                    folderlocation: '$(Pipeline.Workspace)/npm-packages'
+                    waitforreleasecompletion: true
+                    owners: '$(EsrpOwners)'
+                    approvers: '$(EsrpApprovers)'
+                    serviceendpointurl: '$(EsrpServiceEndpointUrl)'
+                    mainpublisher: '$(EsrpMainPublisher)'
+                    domaintenantid: '$(EsrpDomainTenantId)'

--- a/azure-pipelines-steps-node.yml
+++ b/azure-pipelines-steps-node.yml
@@ -20,19 +20,14 @@ steps:
   workingDirectory: node
   displayName: (task-lib) npm test
 
-# Only on Linux. For CI runs on master, automatically publish packages
-- ${{ if eq(parameters.os, 'Linux') }}:
-  - bash: |
-      echo //registry.npmjs.org/:_authToken=\${NPM_TOKEN} > .npmrc
-      npm publish || true # Ignore publish failures, usually will happen because package already exists
-    displayName: (task-lib) npm publish
-    workingDirectory: node/_build
-    condition: and(succeeded(), in(variables['build.reason'], 'IndividualCI', 'BatchedCI', 'Manual'), in(variables['build.sourcebranch'], 'refs/heads/master'))
-    env:
-      NPM_TOKEN: $(npm-automation.token)
-
-  # PublishPipelineArtifact step is configured in the base template.
-  # See the templateContext section in the azure-pipelines.yml file
+# NOTE: npm publishing has been removed from this CI template.
+# This template is now used for PR/CI validation only (build + test).
+# Publishing the package to npmjs.org is handled by the dedicated release
+# pipeline (azure-pipelines-release.yml) via the ESRP Release task.
+#
+# The Linux CI job still publishes the built package as the 'npm-package'
+# pipeline artifact through the base template's templateContext section
+# (see azure-pipelines.yml).
 
 # Only on Windows. Build VstsTaskSdk for powershell 
 - ${{ if eq(parameters.os, 'Windows_NT') }}:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,9 @@ trigger:
 - releases/*
 
 variables:
-- group: npm-tokens
+# npm publishing has moved to the dedicated ESRP release pipeline
+# (azure-pipelines-release.yml), so the npm-tokens variable group and the
+# npm-automation.token secret are no longer consumed by CI.
 - name: nodeVersion
   value: '16.13.0'
 - name: nodeVersionForPowershell

--- a/docs/esrp-npm-release.md
+++ b/docs/esrp-npm-release.md
@@ -1,0 +1,158 @@
+# Releasing `azure-pipelines-task-lib` to npm via ESRP
+
+This package is published to [npmjs.org](https://www.npmjs.com/package/azure-pipelines-task-lib)
+by the **ESRP Release** (`EsrpRelease`) task, **not** by `npm publish`.
+
+- **CI / PR builds** (`azure-pipelines.yml`) only build and test the package.
+  They no longer publish anything.
+- **Releases** run the dedicated pipeline **`azure-pipelines-release.yml`**, which
+  builds, tests, packs a `.tgz`, and hands it to ESRP for publication.
+
+## How it works
+
+```
+Build stage        Package stage             PublishToNpmViaESRP stage
+-----------        -------------             -------------------------
+npm ci             download build-output     download npm-packages
+npm run build  ->  npm pack (.tgz)       ->  verify >= 1 .tgz
+npm test           publish 'npm-packages'    EsrpRelease@12  ->  npmjs.org
+publish _build     artifact
+```
+
+Key facts about ESRP:
+
+- **ESRP only publishes pre-built `.tgz` files.** It does **not** run `npm pack`.
+  This pipeline runs `npm pack` in the Package stage and gives ESRP a folder of
+  `.tgz` files (`contentsource: Folder` + `folderlocation`).
+- **npm publication is performed by the ESRP Release task**, which adds signing,
+  provenance, and an approval/notification workflow on top of the npm publish.
+- **The npm dist-tag is inferred from `publishConfig.tag`** in `package.json`.
+  When it is not set (as today), ESRP publishes under `latest`. `EsrpRelease@12`
+  can also pin the tag explicitly via the `productstate` input.
+
+## Network constraints (no public registry access)
+
+The build agents **cannot reach the public npm registry** (`registry.npmjs.org`).
+The pipeline is designed around this:
+
+- `npm ci`, `npm pack`, and the idempotency lookup all go through the **internal
+  ADO feed** configured in the repo `.npmrc`
+  (`pkgs.dev.azure.com/mseng/PipelineTools/.../PipelineTools_PublicPackages`),
+  authenticated with `NpmAuthenticate@0`. Nothing on the agent calls npmjs.
+- The **actual publish to npmjs.org is performed by ESRP**, out-of-band through
+  the ESRP service — not by the agent. That is why the agent never needs public
+  registry access.
+
+## Running a release
+
+1. Go to Pipelines → run **`azure-pipelines-release.yml`** manually.
+2. Optionally tick **Dry run** to build + pack only and skip the ESRP publish
+   (useful to validate a release candidate).
+3. Approve the ESRP notification/approval request when prompted (owners/approvers
+   below receive it).
+
+## Required variables
+
+Create a variable group named **`esrp-npm-release`** (Pipelines → Library) with the
+following. None of these are secrets — they are resource identifiers — but keeping
+them in a group lets you rotate/override without editing the pipeline.
+
+| Variable | Description | Example |
+| --- | --- | --- |
+| `EsrpServiceConnection` | Name of the Azure Resource Manager service connection (Workload Identity Federation / OIDC) used to authenticate to Azure/Key Vault. | `TaskLib_ESRP_Release` |
+| `EsrpKeyVault` | Key Vault that holds the ESRP signing (TSS) certificate. | `tasklib-release-akv` |
+| `EsrpSignCert` | Name of the signing certificate in that Key Vault. | `TaskLib-ESRP-CERT` |
+| `EsrpClientId` | Client (app) id of the identity **registered and approved** with ESRP as the publisher. Must be the same identity the service connection federates to, and it must have `Key Vault Certificate User` on `EsrpKeyVault`. | `00000000-0000-0000-0000-000000000000` |
+| `EsrpOwners` | **Comma-separated** notification owner emails. Prefer a team DL/security group. | `my-team@microsoft.com` |
+| `EsrpApprovers` | **Comma-separated** notification approver emails. | `my-team@microsoft.com` |
+
+> ⚠️ **Owners/Approvers are split on `,` (comma), not `;`.** A semicolon is treated
+> as part of a single address and rejected as an invalid email.
+
+The following non-secret constants are set inline in `azure-pipelines-release.yml`
+with defaults for public-npm (OSS) publishing. Override them in the variable group
+only if your ESRP onboarding differs:
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `EsrpMainPublisher` | `ESRPRELPACMAN` | ESRP OSS publisher used for public npm. |
+| `EsrpServiceEndpointUrl` | `https://api.esrp.microsoft.com` | ESRP API endpoint. |
+| `EsrpDomainTenantId` | `975f013f-7f24-47e8-a7d3-abc4752bf346` | Tenant of the `ESRPRELPACMAN` OSS publisher. |
+
+## Service connection prerequisites
+
+1. An **Azure Resource Manager service connection** configured with **Workload
+   Identity Federation (OIDC)** — no secrets stored in ADO.
+2. The managed identity / app backing that connection must:
+   - be **registered and approved** as your ESRP **publisher** identity, and
+   - have **`Key Vault Certificate User`** on the Key Vault (`EsrpKeyVault`) that
+     holds the ESRP signing certificate.
+
+**Why a signing cert + Key Vault are still required even with WIF:** the service
+connection (WIF) handles *authentication* to Azure/Key Vault. ESRP *additionally*
+requires the release request payload itself to be cryptographically signed by a
+registered publisher certificate (the TSS cert). That is a non-negotiable ESRP
+requirement, independent of how the pipeline authenticates. The cert lives in Key
+Vault so it can be rotated without touching the service connection.
+
+## ESRP onboarding checklist
+
+- [ ] Install the **"ESRP Release"** Azure DevOps extension in the project
+      (request via `esrprelpm@microsoft.com` if it is not already installed).
+- [ ] Onboard/register an ESRP **publisher** identity and get it **Approved**
+      (ESRP Portal → Onboarding → Release = Approved).
+- [ ] Create the Key Vault and import the ESRP **signing certificate**; grant the
+      publisher identity **`Key Vault Certificate User`**.
+- [ ] Create the **WIF Azure RM service connection** federated to that identity.
+- [ ] Confirm `azure-pipelines-task-lib` is on ESRP's npm **publisher allow-list**
+      (the identity must have publish rights for the package/scope on npmjs).
+- [ ] Create the **`esrp-npm-release`** variable group with the values above.
+- [ ] Do a **Dry run** first, then a real release.
+
+> **Publisher allow-list:** ESRP only has publish rights for a fixed set of npm
+> packages/scopes tied to the publisher. If `azure-pipelines-task-lib` is not yet
+> covered, publishing fails until ESRP is configured for it (contact
+> `esrprelpm@microsoft.com`).
+
+## Troubleshooting
+
+**403 Forbidden from npm during ESRP publish**
+- The version already exists — npm rejects republishing an existing version.
+  The pipeline guards against this: an "idempotent" step checks the **internal
+  ADO feed** first (the agent cannot reach public npmjs) and **skips ESRP when
+  `name@version` is already available**, so a re-run is a no-op. To publish new
+  content, bump `version` in `node/package.json`.
+- The ESRP publisher is not a **collaborator/owner** of `azure-pipelines-task-lib`
+  on npmjs, or the package/scope is not on ESRP's publisher allow-list. Ask the
+  ESRP team to add the publisher as an npm owner/collaborator for the package.
+
+**2FA / OTP required**
+- With ESRP you must **not** use a personal npm token or 2FA. Publishing is done
+  by ESRP's automation identity. If you see a 2FA/OTP prompt, the release is
+  (incorrectly) going through an interactive `npm publish` path instead of ESRP —
+  make sure you are running `azure-pipelines-release.yml`, not the old CI publish.
+
+**Missing collaborator / "you do not have permission to publish"**
+- The ESRP publisher identity lacks publish rights for this package. This is an
+  ESRP-side npm permission; open a request with `esrprelpm@microsoft.com` to grant
+  the ESRP OSS publisher access to `azure-pipelines-task-lib`.
+
+**No `.tgz` files found / release fails before ESRP**
+- The Package stage did not produce a tarball. Check the `npm pack` step logs.
+  The pipeline intentionally **fails fast** (see the "Verify at least one .tgz
+  exists" and "Verify packages exist before ESRP" steps) rather than submit an
+  empty ESRP request.
+- `package.json` is marked **`"private": true`** — the "Validate package.json is
+  publishable" step blocks this. Remove `private` to publish.
+
+**Auth / cert / Key Vault errors from the ESRP task**
+- Verify `EsrpClientId` is the **approved publisher** app (not just the app backing
+  the service connection), that it has `Key Vault Certificate User` on
+  `EsrpKeyVault`, and that `EsrpSignCert` / `EsrpDomainTenantId` are correct.
+- A known ESRP smoke-test is to submit with `contenttype: 'Maven'` instead of
+  `'npm'`: ESRP authenticates and accepts the request, then fails at content
+  validation — proving the auth/cert/KV wiring works without publishing anything.
+
+**Wrong npm dist-tag**
+- Set `publishConfig.tag` in `node/package.json` (ESRP infers the tag from it), or
+  pin it explicitly with the `productstate` input on the `EsrpRelease@12` task.


### PR DESCRIPTION
## Summary

Migrates npm publishing of `azure-pipelines-task-lib` off `npm publish` and onto Microsoft's internal **ESRP Release** (`EsrpRelease@12`). Existing CI now only builds/tests (PR builds); a new dedicated pipeline performs the release.

[AB#2440593](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2440593)

## Changes

- **New `azure-pipelines-release.yml`** — release pipeline extending the 1ES Official template, with three stages:
  - **Build** — `npm ci` / `npm run build` / tests; publishes `build-output` (`node/_build`).
  - **Package** — validates `package.json` is not `private`, runs `npm pack` into the staging dir, verifies at least one `.tgz` exists, publishes the `npm-packages` artifact.
  - **PublishToNpmViaESRP** — 1ES `releaseJob` (`isProduction: true`); authenticates to the internal ADO feed, runs an idempotency check, and invokes `EsrpRelease@12` (`intent: PackageDistribution`, `contenttype: npm`, `contentsource: Folder`, `waitforreleasecompletion: true`, `mainpublisher: ESRPRELPACMAN`).
- **`azure-pipelines-steps-node.yml`** — removed the old `npm publish` block; CI is now build/test only.
- **`azure-pipelines.yml`** — removed the `npm-tokens` variable group (only the old publish step used it).
- **`docs/esrp-npm-release.md`** — onboarding, required variables, service-connection prerequisites, ESRP onboarding checklist, and troubleshooting.

## Network constraint

The release agent **cannot reach the public npm registry**. All agent-side npm operations (`npm ci`, the idempotency `npm view`) go through the internal ADO feed via the repo `.npmrc` + `NpmAuthenticate@0`. ESRP performs the actual publish to npmjs **out-of-band** through the ESRP service.

## Prerequisites before first run

- Provision the **ESRP WIF/managed-identity service connection** and the `esrp-npm-release` variable group (Key Vault, signing cert, client id, owners/approvers).
- Grant the pipeline's **Build Service identity** read access to the `PipelineTools_PublicPackages` feed (used by `NpmAuthenticate@0`).

> Note: `NpmAuthenticate@0` for the same-org ADO feed needs **no** service connection — only a feed ACL. The single service connection required is the ESRP WIF one.