### PR TITLE
Fix ESRP release job: check out self so .npmrc is present

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -223,6 +223,16 @@ extends:
                     artifactName: npm-packages
                     targetPath: $(Pipeline.Workspace)/npm-packages
               steps:
+                # 1ES release jobs (templateContext.type: releaseJob) do NOT
+                # check out the repository by default, unlike the regular CI jobs
+                # in azure-pipelines.yml which rely on the template's implicit
+                # `checkout: self`. We check out self here for the SAME reason CI
+                # does: the internal-feed .npmrc must be on disk so NpmAuthenticate
+                # can inject credentials and the idempotency `npm view` below can
+                # resolve the registry. Without this, .npmrc is missing and the
+                # feed auth step fails.
+                - checkout: self
+
                 - task: NodeTool@0
                   displayName: 'Use Node $(nodeVersion)'
                   inputs:


### PR DESCRIPTION
## Summary

Follow-up fix for the ESRP npm release pipeline (added in #1187). The `PublishToNpmViaESRP` job uses `templateContext.type: releaseJob`, and **1ES release jobs do not check out the repository by default** — unlike the regular CI jobs, which rely on the 1ES template's implicit `checkout: self`.

Without a checkout, the internal-feed `.npmrc` is absent on the ESRP agent, so:
- `NpmAuthenticate@0` (`workingFile: .npmrc`) fails — the file isn't on disk.
- the ADO-feed idempotency `npm view` (run from `$(Build.SourcesDirectory)`) has no registry config.

## Change

Add an explicit `- checkout: self` as the first step of the ESRP release job, so it has the repo (and `.npmrc`) on disk — matching the checkout behavior the CI pipeline relies on. Single-file, 10-line change; no other files touched.