### PR TITLE
Isolate npm .tgz in a packages/ subfolder so ESRP skips the 1ES SBOM _manifest

### DIFF
--- a/.azure-pipelines/azure-pipelines-build.yml
+++ b/.azure-pipelines/azure-pipelines-build.yml
@@ -119,20 +119,30 @@ extends:
                 workingDirectory: node
 
               # Produce the .tgz that ESRP will publish. ESRP does not pack; we
-              # stage the tarball into $(Build.ArtifactStagingDirectory)/npm-packages
-              # and publish it as the 'npm-packages' artifact (see outputs above).
+              # stage the tarball into a `packages/` SUBFOLDER of the artifact
+              # ($(Build.ArtifactStagingDirectory)/npm-packages/packages) and
+              # publish the parent as the 'npm-packages' artifact (see outputs).
+              #
+              # WHY THE SUBFOLDER: 1ES injects an SBOM `_manifest/` folder at the
+              # ROOT of every published pipeline artifact. If the .tgz sat at the
+              # artifact root next to `_manifest/`, the release pipeline's ESRP
+              # `folderlocation` would enumerate those non-.tgz SBOM files and
+              # fail trying to derive npm name@version from them (ESRP crashes
+              # with "...Received undefined" while submitting the release request).
+              # Keeping the .tgz in `packages/` leaves `_manifest/` a sibling, so
+              # the release points ESRP at `.../npm-packages/packages` (only .tgz).
               - script: |
                   set -e
-                  mkdir -p "$(Build.ArtifactStagingDirectory)/npm-packages"
-                  npm pack --pack-destination "$(Build.ArtifactStagingDirectory)/npm-packages"
+                  mkdir -p "$(Build.ArtifactStagingDirectory)/npm-packages/packages"
+                  npm pack --pack-destination "$(Build.ArtifactStagingDirectory)/npm-packages/packages"
                   echo "Packed contents:"
-                  ls -l "$(Build.ArtifactStagingDirectory)/npm-packages"
+                  ls -l "$(Build.ArtifactStagingDirectory)/npm-packages/packages"
                 displayName: 'npm pack -> staging'
                 workingDirectory: node/_build
 
               # Fail the build if npm pack produced no package files.
               - script: |
-                  count=$(ls -1 "$(Build.ArtifactStagingDirectory)/npm-packages"/*.tgz 2>/dev/null | wc -l)
+                  count=$(ls -1 "$(Build.ArtifactStagingDirectory)/npm-packages/packages"/*.tgz 2>/dev/null | wc -l)
                   echo "Found $count .tgz file(s)."
                   if [ "$count" -eq 0 ]; then
                     echo "ERROR: npm pack produced no .tgz files; nothing to release."
@@ -146,7 +156,7 @@ extends:
               # tarball, fail here rather than shipping a polluted npm package.
               - script: |
                   set -e
-                  for tgz in "$(Build.ArtifactStagingDirectory)/npm-packages"/*.tgz; do
+                  for tgz in "$(Build.ArtifactStagingDirectory)/npm-packages/packages"/*.tgz; do
                     echo "Inspecting $tgz for stray _manifest/ entries..."
                     if tar -tzf "$tgz" | grep -E '(^|/)_manifest/' ; then
                       echo "ERROR: '$tgz' contains an SBOM/_manifest folder; refusing to publish it inside the npm package."

--- a/.azure-pipelines/azure-pipelines-release.yml
+++ b/.azure-pipelines/azure-pipelines-release.yml
@@ -108,7 +108,10 @@ extends:
               inputs:
                 # Download the .tgz produced by the 'build' pipeline resource.
                 # This is a declarative 1ES input (the template performs the
-                # download), so the job body stays a single ESRP task.
+                # download), so the job body stays a single ESRP task. The
+                # artifact contains packages/<name>.tgz plus a 1ES-injected
+                # SBOM `_manifest/` folder at its root; ESRP is pointed at the
+                # `packages/` subfolder below so it only ever sees the .tgz.
                 - input: pipelineArtifact
                   pipeline: build
                   artifactName: npm-packages
@@ -121,6 +124,13 @@ extends:
               #   waitforreleasecompletion=true                 -> block until done
               # ESRP does NOT run npm pack; it distributes the .tgz downloaded
               # above. The dist-tag is inferred from publishConfig.tag (latest).
+              #
+              # folderlocation points at the `packages/` SUBFOLDER of the
+              # downloaded artifact -- NOT its root. The build stages the .tgz
+              # there so it is isolated from the 1ES-injected SBOM `_manifest/`
+              # folder (which lands at the artifact root). ESRP must see ONLY
+              # .tgz files here; any non-.tgz sibling makes it fail deriving npm
+              # name@version ("...Received undefined" at release-request submit).
               # NOTE: EsrpRelease@12 also accepts `productstate: <tag>` to pin the
               # npm dist-tag explicitly (e.g. 'latest' or 'beta'); we intentionally
               # omit it and let publishConfig.tag drive the tag per requirements.
@@ -135,7 +145,7 @@ extends:
                   intent: 'PackageDistribution'
                   contenttype: 'npm'
                   contentsource: 'Folder'
-                  folderlocation: '$(Pipeline.Workspace)/npm-packages'
+                  folderlocation: '$(Pipeline.Workspace)/npm-packages/packages'
                   waitforreleasecompletion: true
                   owners: '$(EsrpOwners)'
                   approvers: '$(EsrpApprovers)'


### PR DESCRIPTION
## Problem

The ESRP release pipeline (`azure-pipelines-task-lib.Release`) fails every run at the `EsrpRelease@12` task:

```
Error while submitting request to Release Gateway
Execution failed with error :- The first argument must be of type string or an
instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received undefined
```

Auth, cert fetch, OIDC, gateway session, and the file upload all succeed — the crash is client-side while building the release request.

## Root cause (confirmed from pipeline logs)

1ES injects an SBOM `_manifest/` folder at the **root** of every published pipeline artifact. The build's `npm-packages` artifact therefore contains the real `.tgz` **plus 10 non-`.tgz` `_manifest/*` files** (spdx manifests, cose, cat, comparison-result, ESRPClientLogs).

The release job downloads the whole artifact to `$(Pipeline.Workspace)/npm-packages` and pointed ESRP `folderlocation` at that root. With `contenttype: npm` + `contentsource: Folder`, ESRP enumerates **every** file in the folder and tries to derive npm `name@version` from each. The `_manifest` files yield `undefined`, which is then passed to a `crypto`/`Buffer` operation → `Received undefined`. This also violates the ESRP doc requirement that `folderlocation` contain only prebuilt `.tgz` packages.

The download log (build `20260730.3`) shows the 11-file artifact — the `.tgz` alongside `_manifest/` — and the SBOM-validation step reading `.../npm-packages/_manifest/spdx_2.2/manifest.spdx.json`, confirming `_manifest/` sits at the folder root next to the tarball.

> Note on `productname`/`productversion=undefined` in the logs: those are **unset optional task inputs** (`INPUT_* = ''`), printed at config-load ~1s **before** the tarball is even processed — not failed metadata reads. They are not the trigger.

## Fix

Keep the release job to **only** the ESRP task (no filter/copy step) by isolating the tarball on the build side:

- **Build** (`azure-pipelines-build.yml`): `npm pack` into `$(Build.ArtifactStagingDirectory)/npm-packages/packages`; still publish the parent as the `npm-packages` artifact. 1ES adds `_manifest/` at the artifact root, so it becomes a **sibling** of `packages/`. Verify/idempotency steps updated to the new path.
- **Release** (`azure-pipelines-release.yml`): `folderlocation: $(Pipeline.Workspace)/npm-packages/packages` → ESRP sees only the `.tgz`. The artifact download target stays the artifact root.

## Validation

- Both pipeline YAML files parse cleanly.
- **Requires an end-to-end re-run to confirm**: queue `azure-pipelines-task-lib.Build`, then the Release pipeline against that run, and verify ESRP gets past "submitting request to Release Gateway".

## Follow-ups (not in this PR)

- The ESRP task itself is non-robust — it crashes with a cryptic Node error instead of reporting an invalid package file. Worth reporting to the ESRP team with the failing CorrelationId.
- Publisher allow-list / npmjs collaborator / publish-2FA prerequisites (if any) would surface **after** the gateway submission succeeds and are unaffected by this change.