### PR TITLE
Fix js-yaml security vulnerabilities in task-lib

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "5.279.0",
+  "version": "5.280.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "azure-pipelines-task-lib",
-      "version": "5.279.0",
+      "version": "5.280.0",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.6.0",
@@ -781,9 +781,9 @@
       "license": "ISC"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha1-ASFsAB1n9I4s1WDXCMevIQkKOEg=",
+      "version": "4.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha1-jkT7FKJkPFlya7FXh7XxUSyz0/s=",
       "dev": true,
       "funding": [
         {

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-task-lib",
-  "version": "5.279.0",
+  "version": "5.280.0",
   "description": "Azure Pipelines Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",
@@ -47,7 +47,7 @@
   "overrides": {
     "brace-expansion@1.x": { ".": "1.1.18" },
     "brace-expansion@2.x": { ".": "2.1.4" },
-    "js-yaml": "4.3.1",
+    "js-yaml": "4.3.2",
     "serialize-javascript": "7.0.5"
   }
 }

--- a/powershell/package-lock.json
+++ b/powershell/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vsts-task-sdk",
-  "version": "0.21.6",
+  "version": "0.21.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vsts-task-sdk",
-      "version": "0.21.6",
+      "version": "0.21.7",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",
@@ -910,9 +910,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha1-ASFsAB1n9I4s1WDXCMevIQkKOEg=",
+      "version": "4.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha1-jkT7FKJkPFlya7FXh7XxUSyz0/s=",
       "dev": true,
       "funding": [
         {

--- a/powershell/package.json
+++ b/powershell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-task-sdk",
-  "version": "0.21.6",
+  "version": "0.21.7",
   "private": true,
   "scripts": {
     "build": "node make.js build",
@@ -21,7 +21,7 @@
   },
   "overrides": {
     "brace-expansion@2.x": { ".": "2.1.4" },
-    "js-yaml": "4.3.1",
+    "js-yaml": "4.3.2",
     "serialize-javascript": "7.0.5"
   }
 }


### PR DESCRIPTION
### **Description**
Updated js-yaml  to non-vulnerable version to fix the vulnerabilities.

---

### **Changes**
in node
- Bump azure-pipelines-task-lib version: 5.279.0 → 5.280.0
- Bump js-yaml : 4.3.1 → 4.3.2
npm audit output
<img width="603" height="67" alt="image" src="https://github.com/user-attachments/assets/36b12ac4-a457-437e-b297-bef5b2afdeb4" />

in powershell
- Bump version :0.21.6 → 0.21.7
- Bump js-yaml : 4.3.1 → 4.3.2
npm audit output
<img width="608" height="59" alt="image" src="https://github.com/user-attachments/assets/5305f421-a555-4994-a110-38911009c500" />


---

### **Files changed**
- node/package.json
- node/package-lock.json
- powershell/package.json
- powershell/package-lock.json

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Change Behind Feature Flag** (Yes / No)
No

---

### **Tech Design / Approach**
No

---

### **Documentation Changes Required** (Yes/No)
No

---

### **Unit Tests Added or Updated** (Yes / No)  
No

---

**Testing**
Ran node make.js build locally and observed no failures.

---

### **Logging Added/Updated** (Yes/No)
No

--- 

### **Telemetry Added/Updated** (Yes/No) 
No

---

### **Rollback Scenario and Process** (Yes/No)
NA

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected

