### PR TITLE
Load the bundled PowerShell security module

### DIFF
--- a/powershell/Tests/L0/Import-Module.LoadsBundledSecurity.ps1
+++ b/powershell/Tests/L0/Import-Module.LoadsBundledSecurity.ps1
@@ -1,0 +1,67 @@
+[CmdletBinding()]
+param()
+
+. $PSScriptRoot\..\lib\Initialize-Test.ps1
+
+# Import in fresh processes because the standard test initializer preloads Security.
+$executable = if ($PSVersionTable.PSEdition -eq 'Core') {
+    if ($env:OS -eq 'Windows_NT') { Join-Path $PSHOME 'pwsh.exe' } else { Join-Path $PSHOME 'pwsh' }
+} else {
+    Join-Path $PSHOME 'powershell.exe'
+}
+$sdkPath = Join-Path (Get-Module VstsTaskSdk).ModuleBase 'VstsTaskSdk.psd1'
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ([guid]::NewGuid().ToString())
+$shadowModule = Join-Path $tempRoot 'Microsoft.PowerShell.Security'
+$null = New-Item -ItemType Directory -Path $shadowModule -Force
+Set-Content -LiteralPath (Join-Path $shadowModule 'Microsoft.PowerShell.Security.psd1') -Value @"
+@{ ModuleVersion = '1.0'; RootModule = 'Security.psm1' }
+"@
+Set-Content -LiteralPath (Join-Path $shadowModule 'Security.psm1') -Value @'
+throw 'The shadow security module must not be imported.'
+'@
+
+$childScript = @'
+param($sdkPath, $shadowPath, $preload)
+$ErrorActionPreference = 'Stop'
+$PSModuleAutoloadingPreference = 'None'
+try {
+    Import-Module Microsoft.PowerShell.Management
+    Import-Module Microsoft.PowerShell.Utility
+    $bundledModule = Join-Path $PSHOME 'Modules/Microsoft.PowerShell.Security/Microsoft.PowerShell.Security.psd1'
+    if ($preload) {
+        Import-Module -Name $bundledModule
+    } else {
+        Remove-Module Microsoft.PowerShell.Security -ErrorAction SilentlyContinue
+    }
+    $env:PSModulePath = $shadowPath + [System.IO.Path]::PathSeparator + $env:PSModulePath
+    Import-Module -Name $sdkPath -ArgumentList @{ NonInteractive = $true }
+    $sdk = Get-Module VstsTaskSdk
+    $loadedPath = & $sdk { (Get-Module Microsoft.PowerShell.Security).Path }
+    if ($loadedPath -ne $bundledModule) {
+        throw "Expected bundled Security module, got '$loadedPath'."
+    }
+    & $sdk {
+        $secure = ConvertTo-SecureString -String 'test secret' -AsPlainText -Force
+        if ($secure.Length -ne 11) { throw 'SecureString conversion failed.' }
+    }
+    [Console]::WriteLine('BUNDLED_SECURITY_LOADED')
+    exit 0
+} catch {
+    [Console]::Error.WriteLine($_.Exception.Message)
+    exit 1
+}
+'@
+
+try {
+    foreach ($preload in @('$false', '$true')) {
+        $command = "& { $childScript } '$($sdkPath.Replace("'", "''"))' '$($tempRoot.Replace("'", "''"))' $preload"
+        $encoded = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($command))
+        $output = & $executable -NoLogo -NoProfile -NonInteractive -EncodedCommand $encoded 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            throw "SDK import failed (preload=$preload): $($output -join [Environment]::NewLine)"
+        }
+        Assert-AreEqual 'BUNDLED_SECURITY_LOADED' ($output -join [Environment]::NewLine)
+    }
+} finally {
+    Remove-Item -LiteralPath $tempRoot -Recurse -Force
+}

--- a/powershell/VstsTaskSdk/VstsTaskSdk.psm1
+++ b/powershell/VstsTaskSdk/VstsTaskSdk.psm1
@@ -114,10 +114,11 @@ $scriptText = @"
 # Load the SDK resource strings.
 Import-LocStrings "$PSScriptRoot\lib.json"
 
-# Load the module that contains ConvertTo-SecureString.
+# Load the bundled module that contains ConvertTo-SecureString. An import by name
+# can select a Windows PowerShell module and trigger compatibility-mode proxies.
 if (!(Get-Module -Name Microsoft.PowerShell.Security)) {
     Write-Verbose "Importing the module 'Microsoft.PowerShell.Security'."
-    Import-Module -Name Microsoft.PowerShell.Security 2>&1 |
+    Import-Module -Name "$PSHOME\Modules\Microsoft.PowerShell.Security\Microsoft.PowerShell.Security.psd1" 2>&1 |
         ForEach-Object {
             if (`$_ -is [System.Management.Automation.ErrorRecord]) {
                 Write-Verbose `$_.Exception.Message


### PR DESCRIPTION
Fixes #1204.

Import `Microsoft.PowerShell.Security` from the running shell's bundled manifest under `$PSHOME`, rather than resolving it through `PSModulePath`. This avoids selecting a Windows PowerShell module and entering compatibility-mode proxy generation. The already-loaded guard and existing error handling are unchanged.

Adds an L0 regression that prepends a conflicting module directory, imports the built SDK in fresh child processes, and verifies the bundled module and SecureString conversion. It covers both initially unloaded and preloaded Security modules and fails before the fix.

Validation on macOS arm64 with PowerShell 7.6.5:
- `npm run build` passed.
- 14 focused L0 scripts passed, including both new import cases.
- Three other selected scripts (`Get-Endpoint.MasksAuth`, `Get-TaskVariable.FormatsName`, and `Set-TaskVariable.SetsValue`) report the same failures on unmodified source.
- `git diff --check` passed.

Windows PowerShell 5.1 and the reported sysprepped Windows environment were not available locally. The new script is included in the existing Windows L0 test discovery.
