### PR TITLE
Configure release network isolation policies

### DIFF
--- a/.azure-pipelines/azure-pipelines-release.yml
+++ b/.azure-pipelines/azure-pipelines-release.yml
@@ -80,7 +80,7 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     settings:
-      networkIsolationMode: Audit
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3,GitHub
     sdl:
       sourceAnalysisPool:
         name: 1ES-ABTT-Shared-Pool


### PR DESCRIPTION
Release publishing needs permissive access through the approved CFSClean and GitHub policies rather than relying on report-only audit mode.

Updates the 1ES `networkIsolationPolicy` to `Permissive,CFSClean,CFSClean2,CFSClean3,GitHub`, following the policy configuration used by the Google Play extension pipelines.