### PR TITLE
Use monitored unrestricted release policy

### DIFF
--- a/.azure-pipelines/azure-pipelines-release.yml
+++ b/.azure-pipelines/azure-pipelines-release.yml
@@ -80,7 +80,7 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     settings:
-      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3,GitHub
+      networkIsolationPolicy: Monitored.Unrestricted,CFSClean,CFSClean2,CFSClean3,GitHub
     sdl:
       sourceAnalysisPool:
         name: 1ES-ABTT-Shared-Pool


### PR DESCRIPTION
The release pipeline should match the network isolation configuration used by the Google Play extension rather than using the `Permissive` policy token.

This replaces `Permissive` with `Monitored.Unrestricted` while retaining `CFSClean`, `CFSClean2`, `CFSClean3`, and `GitHub`.