### PR TITLE
Remove explicit node installation in favor agent node

### DIFF
--- a/.azure-pipelines/azure-pipelines-release.yml
+++ b/.azure-pipelines/azure-pipelines-release.yml
@@ -111,10 +111,11 @@ extends:
                   targetPath: $(Build.ArtifactStagingDirectory)/npm-packages
                   artifactName: npm-packages
             steps:
-              - task: NodeTool@0
-                displayName: 'Use Node $(nodeVersion)'
-                inputs:
-                  versionSpec: $(nodeVersion)
+              # Failing network isolation so commenting out.
+              # - task: NodeTool@0
+              #   displayName: 'Use Node $(nodeVersion)'
+              #   inputs:
+              #     versionSpec: $(nodeVersion)
 
               # Authenticate to the internal ADO npm feed referenced by .npmrc so
               # `npm ci` (and the idempotency `npm view` below) can reach it. The

--- a/.azure-pipelines/azure-pipelines-steps-node.yml
+++ b/.azure-pipelines/azure-pipelines-steps-node.yml
@@ -3,10 +3,11 @@ parameters:
   type: string
 
 steps:
-- task: UseNode@1
-  displayName: use node $(nodeVersion)
-  inputs:
-    version: $(nodeVersion)
+# Failing network isolation so commenting out
+# - task: UseNode@1
+#   displayName: use node $(nodeVersion)
+#   inputs:
+#     version: $(nodeVersion)
 
 - task: NpmAuthenticate@0
   inputs:
@@ -48,10 +49,11 @@ steps:
       projects: 'powershell/CompiledHelpers/VstsTaskSdk.csproj'
       arguments: '--configuration Release --no-restore'
 
-  - task: UseNode@1
-    displayName: use node $(nodeVersionForPowershell) for PowerShell SDK
-    inputs:
-      version: $(nodeVersionForPowershell)
+  # Failing network isolation so commenting out
+  # - task: UseNode@1
+  #   displayName: use node $(nodeVersionForPowershell) for PowerShell SDK
+  #   inputs:
+  #     version: $(nodeVersionForPowershell)
 
   - task: NpmAuthenticate@0
     inputs:

--- a/node/test/dirtests.ts
+++ b/node/test/dirtests.ts
@@ -1669,7 +1669,10 @@ describe('Dir Operation Tests', function () {
         testutil.createSymlinkDir(symlinkDirectory, symlinkLevel2Directory);
         assert.equal(fs.readFileSync(path.join(symlinkDirectory, 'real_file')), 'test file content');
         if (os.platform() == 'win32') {
-            assert.equal(fs.readlinkSync(symlinkLevel2Directory), symlinkDirectory + '\\');
+            assert.equal(
+                path.resolve(fs.readlinkSync(symlinkLevel2Directory)),
+                path.resolve(symlinkDirectory)
+            );
         }
         else {
             assert.equal(fs.readlinkSync(symlinkLevel2Directory), symlinkDirectory);

--- a/node/test/dirtests.ts
+++ b/node/test/dirtests.ts
@@ -25,19 +25,17 @@ describe('Dir Operation Tests', function () {
 
     });
 
-    // this test verifies the expected version of node is being used to run the tests.
-    // 5.10.1 is what ships in the 1.x and 2.x agent.
-    it('is expected version', function (done) {
-        this.timeout(1000);
-
-        console.log('node version: ' + process.version);
-        const supportedNodeVersions = ['v16.13.0'];
-        if (supportedNodeVersions.indexOf(process.version) === -1) {
-            assert.fail(`expected node node version to be one of ${supportedNodeVersions.map(o => o).join(', ')}. actual: ` + process.version);
-        }
-
-        done();
-    });
+    // it('is expected version', function (done) {
+    //     this.timeout(1000);
+    //
+    //     console.log('node version: ' + process.version);
+    //     const supportedNodeVersions = ['v16.13.0'];
+    //     if (supportedNodeVersions.indexOf(process.version) === -1) {
+    //         assert.fail(`expected node node version to be one of ${supportedNodeVersions.map(o => o).join(', ')}. actual: ` + process.version);
+    //     }
+    //
+    //     done();
+    // });
 
     // which tests
     it('which() finds file name', function (done) {


### PR DESCRIPTION
Remove the Node installation step and the respective test case to avoid pipeline failures while figuring out network isolation.

Temporary change will try to point to another usable node js mirror and update it